### PR TITLE
migrate from REST to websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,172 @@
 # SarradaBet
 
-SarradaBet is a mock betting platform that demonstrates how to combine a TypeScript backend, a React frontend, and shared types in a single Turborepo workspace. The project highlights clean architecture patterns, strong validation, and real time event processing over PostgreSQL.
+SarradaBet is a mock betting platform built as a Turborepo monorepo. It combines an Express API, a React frontend, and shared TypeScript contracts, with real-time odds updates over Socket.io and PostgreSQL.
 
 ## Key Features
 
 - Create and manage betting markets, odds, and categories with full CRUD support.
-- Capture user votes and mirror the results in near real time on the web client.
-- Enforce request validation, rate limiting, and structured error responses.
-- Share TypeScript types and helper utilities between the API and the frontend.
+- **Real-time updates** — vote counts and bet changes push instantly to all connected clients via Socket.io (no polling).
+- **Optimistic UI** — votes feel instant; the client reconciles with server events on success or rolls back on error.
+- Request validation, rate limiting, compression, and structured error responses on the API.
+- In-memory caching for categories and resolved bets, plus slim list payloads for faster responses.
+- Shared types in `packages/types` (`@sarradabet/types`) consumed by both API and web.
+
+## Tech Stack
+
+| Layer | Stack |
+|-------|-------|
+| Frontend | React, Vite, Tailwind CSS — deploy on **Vercel** |
+| Backend | Express, Socket.io, Prisma — deploy on **Render** |
+| Database | PostgreSQL — **Supabase** (or local Docker) |
+| Monorepo | Turborepo, shared `@sarradabet/types` |
 
 ## Project Layout
 
 ```
 sarradabet/
 ├── apps/
-│   ├── api/    # Express API with Prisma and PostgreSQL
-│   └── web/    # React application built with Vite and Tailwind CSS
+│   ├── api/    # Express API, Prisma, Socket.io, node-cache
+│   └── web/    # React SPA, RealtimeProvider, optimistic voting UI
 ├── packages/
-│   └── types/  # Shared TypeScript contracts
-├── docs/       # Architectural notes and reference material
+│   └── types/  # Shared contracts (bets, categories, realtime events)
+├── docs/       # Architecture, deployment, performance notes
 └── docker-compose.yml
 ```
 
 ## Getting Started
 
-1. Install dependencies:
-   ```bash
-   npm install
-   ```
-2. Copy the example environment file and adjust secrets:
-   ```bash
-   cp apps/api/.env.example apps/api/.env
-   ```
-3. Start the database:
-   ```bash
-   docker-compose up -d postgres
-   ```
-4. Run migrations and seed data:
-   ```bash
-   cd apps/api
-   npm run prisma:migrate:dev
-   ```
-5. Launch the development servers from the repository root:
-   ```bash
-   npm run dev
-   ```
+### Prerequisites
 
-The API listens on `http://localhost:3001` and the web client on `http://localhost:3002`.
+- Node.js ≥ 20
+- Docker (for local Postgres), or a Supabase project
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+**Local development (Docker Postgres)** — defaults in `.env.example` work out of the box:
+
+| Variable | Purpose |
+|----------|---------|
+| `DATABASE_URL` | Postgres connection (`localhost:5433` via Docker) |
+| `DIRECT_URL` | Direct Postgres URL for Prisma migrations (same as `DATABASE_URL` locally) |
+| `CORS_ORIGINS` | Must include the web dev URL (`http://localhost:3002`) |
+| `VITE_API_URL` | Web → API base URL (`http://localhost:8000`) |
+
+**Supabase (production / remote DB)** — edit `apps/api/.env`:
+
+```env
+DATABASE_URL=postgresql://...@...pooler.supabase.com:6543/postgres?pgbouncer=true
+DIRECT_URL=postgresql://...@...supabase.com:5432/postgres
+```
+
+See [docs/PERFORMANCE.md](docs/PERFORMANCE.md) for pooler setup and query tuning.
+
+### 3. Start the database
+
+```bash
+docker compose up -d db
+```
+
+The service is named `db` (not `postgres`). Postgres listens on host port **5433**.
+
+### 4. Run migrations
+
+```bash
+cd apps/api
+npm run prisma:migrate:dev
+```
+
+Optional seed:
+
+```bash
+npm run db:seed:simple
+```
+
+### 5. Start dev servers
+
+From the repository root:
+
+```bash
+npm run dev
+```
+
+| Service | URL |
+|---------|-----|
+| API (REST) | http://localhost:8000 |
+| API (health) | http://localhost:8000/health |
+| Socket.io | http://localhost:8000/socket.io |
+| Web | http://localhost:3002 |
+
+Vite proxies `/api` and `/socket.io` to the API in dev, so the web app can talk to the backend without CORS issues when using relative paths. With `VITE_API_URL` set, the client connects directly to the API (ensure `CORS_ORIGINS` includes `http://localhost:3002`).
+
+## Real-Time Events
+
+Event names and payloads are defined in `packages/types/src/realtime.ts`:
+
+| Event | When |
+|-------|------|
+| `vote:created` | A user votes on an odd |
+| `bet:created` | A new bet is created |
+| `bet:updated` | Bet updated, closed, or resolved |
+
+The web app wraps routes in `RealtimeProvider`, which patches the query cache when events arrive. Individual `BetCard` components also listen for vote events to update odds locally.
+
+## Deployment
+
+### API (Render)
+
+- Build: `npm run build` (in `apps/api`)
+- Start: `npm run start`
+- Set `DATABASE_URL`, `DIRECT_URL` (Supabase), `CORS_ORIGINS` (your Vercel URL), `JWT_SECRET`, and `PORT`.
+- Render supports WebSockets on the same HTTP service — no extra config needed for a single instance.
+
+### Web (Vercel)
+
+- Root directory: `apps/web`
+- Build: `npm run build`
+- Set `VITE_API_URL` to your Render API URL (e.g. `https://your-api.onrender.com`).
+- [`apps/web/vercel.json`](apps/web/vercel.json) configures SPA rewrites and long-lived cache headers for hashed assets.
+
+### Database migrations (CI / production)
+
+```bash
+npm run prisma:migrate:deploy
+```
+
+Requires `DATABASE_URL` and `DIRECT_URL` secrets (see `.github/workflows/deploy.yml`).
+
+More detail: [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) and [docs/PERFORMANCE.md](docs/PERFORMANCE.md).
 
 ## Testing
 
-- API tests:
-  ```bash
-  cd apps/api
-  npm test
-  ```
-- Web tests:
-  ```bash
-  cd apps/web
-  npm test
-  ```
+```bash
+# All workspaces
+npm test
+
+# API only
+npm run test:api
+
+# Web only
+npm run test:web
+```
 
 ## Security and Observability
 
-- Helmet, CORS configuration, and rate limiting protect the API.
-- Validation uses Zod to guarantee contract fidelity.
-- Logging is centralized through Winston with request identifiers.
+- Helmet, CORS, rate limiting, and response compression on the API.
+- Zod validation on all request bodies and query params.
+- Winston logging with structured output.
+- Admin routes use JWT auth (`JWT_SECRET`); public bet/vote endpoints remain open.
 
 ## Contributing
 
-Please open a pull request with proposed changes and include automated test coverage. Contract updates must stay in sync with the shared types and any downstream consumers.
+Open a pull request with proposed changes and include automated test coverage. When changing API or realtime contracts, update `packages/types` and any downstream consumers in the same PR.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env: cp apps/api/.env.example apps/api/.env
+
+NODE_ENV=development
+PORT=8000
+
+# Web dev server (Vite default in this repo: http://localhost:3002)
+CORS_ORIGINS=http://localhost:3002,http://localhost:5173
+
+# Local Postgres via docker-compose: docker compose up -d db
+DATABASE_URL=postgresql://appuser:sarradabet1234@localhost:5433/sarradabet
+
+# Required by Prisma (direct connection for migrations). Same as DATABASE_URL locally;
+# for Supabase use port 5432 direct host while DATABASE_URL uses the 6543 pooler.
+DIRECT_URL=postgresql://appuser:sarradabet1234@localhost:5433/sarradabet
+
+# Admin JWT (optional for local dev; defaults exist in code)
+JWT_SECRET=dev-jwt-secret-change-me
+JWT_EXPIRES_IN=24h
+
+# Optional
+# API_KEY=
+# USE_IDENTITY_SERVICE=false
+# IDENTITY_SERVICE_URL=http://localhost:3001
+# SERVICE_API_KEY=
+# CONSUL_ENABLED=false

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "@eslint/js": "^9.39.1",
     "@faker-js/faker": "^9.0.0",
     "@types/bcryptjs": "^3.0.0",
+    "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",
     "@types/express-rate-limit": "^5.1.3",
     "@types/jest": "^30.0.0",
@@ -52,9 +53,11 @@
   },
   "dependencies": {
     "@prisma/client": "^6.19.0",
+    "@sarradabet/types": "*",
     "@types/express": "^5.0.0",
     "axios": "^1.7.9",
     "bcryptjs": "^3.0.3",
+    "compression": "^1.8.0",
     "consul": "^1.2.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
@@ -64,8 +67,10 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "node-cache": "^5.1.2",
     "opossum": "^7.0.0",
     "prisma": "^6.19.0",
+    "socket.io": "^4.8.1",
     "winston": "^3.17.0",
     "zod": "^3.24.2"
   }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -55,7 +55,7 @@
     "@prisma/client": "^6.19.0",
     "@sarradabet/types": "*",
     "@types/express": "^5.0.0",
-    "axios": "^1.7.9",
+    "axios": "^1.18.0",
     "bcryptjs": "^3.0.3",
     "compression": "^1.8.0",
     "consul": "^1.2.0",

--- a/apps/api/prisma/migrations/20250614000000_add_bet_performance_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20250614000000_add_bet_performance_indexes/migration.sql
@@ -1,0 +1,3 @@
+-- Add indexes for category filtering and status+created_at list queries
+CREATE INDEX IF NOT EXISTS "bets_categoryId_idx" ON "bets"("categoryId");
+CREATE INDEX IF NOT EXISTS "bets_status_created_at_idx" ON "bets"("status", "created_at" DESC);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -33,6 +33,8 @@ model Bet {
 
   @@index([status])
   @@index([createdAt])
+  @@index([categoryId])
+  @@index([status, createdAt(sort: Desc)])
   @@map("bets")
 }
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import compression from "compression";
 import cors from "cors";
 import morgan from "morgan";
 import { config } from "./config/env";
@@ -10,10 +11,13 @@ import {
   sanitizeRequest,
   corsOptions,
 } from "./core/middleware/SecurityMiddleware";
+import { cacheHeaders } from "./core/middleware/cacheHeaders";
 import router from "./routes";
 import { logger } from "./utils/logger";
 
 export const app = express();
+
+app.use(compression({ threshold: 1024 }));
 
 app.use(securityHeaders);
 app.use(requestSizeLimit("10mb"));
@@ -85,6 +89,7 @@ app.get("/", (req, res) => {
   });
 });
 
+app.use("/api/v1/categories", cacheHeaders({ maxAge: 300, staleWhileRevalidate: 60 }));
 app.use("/api/v1", router);
 
 app.use(notFoundHandler);

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -13,6 +13,10 @@ const envSchema = z.object({
     .string()
     .regex(/^postgresql:\/\/.+/)
     .default("postgresql://postgres:postgres@localhost:5432/sarradabet_test"),
+  DIRECT_URL: z
+    .string()
+    .regex(/^postgresql:\/\/.+/)
+    .optional(),
   API_KEY: z.string().optional(),
   JWT_SECRET: z.string().optional(),
 });

--- a/apps/api/src/controllers/vote.controller.ts
+++ b/apps/api/src/controllers/vote.controller.ts
@@ -1,15 +1,23 @@
 import { Request, Response, NextFunction } from "express";
-import { createVoteWithOdds } from "../repositories/vote.repository";
+import { createVote } from "../services/vote.service";
 import { ApiResponse } from "../utils/api/response";
 
-export const createVote = async (
+export const createVoteHandler = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
   try {
-    const newVote = await createVoteWithOdds(req.body);
-    new ApiResponse(res).success(newVote, 201);
+    const result = await createVote(req.body);
+    new ApiResponse(res).success(
+      {
+        vote: result.vote,
+        betId: result.betId,
+        odds: result.odds,
+        totalVotes: result.totalVotes,
+      },
+      201,
+    );
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/core/cache/CacheService.ts
+++ b/apps/api/src/core/cache/CacheService.ts
@@ -1,0 +1,43 @@
+import NodeCache from "node-cache";
+
+class CacheService {
+  private cache = new NodeCache({
+    stdTTL: 300,
+    checkperiod: 60,
+    useClones: false,
+  });
+
+  get<T>(key: string): T | undefined {
+    return this.cache.get<T>(key);
+  }
+
+  set<T>(key: string, value: T, ttlSeconds?: number): void {
+    if (ttlSeconds !== undefined) {
+      this.cache.set(key, value, ttlSeconds);
+    } else {
+      this.cache.set(key, value);
+    }
+  }
+
+  del(key: string): void {
+    this.cache.del(key);
+  }
+
+  invalidatePattern(prefix: string): void {
+    const keys = this.cache.keys().filter((key) => key.startsWith(prefix));
+    if (keys.length > 0) {
+      this.cache.del(keys);
+    }
+  }
+
+  invalidateBet(betId: number): void {
+    this.del(`bet:${betId}`);
+    this.invalidatePattern("bets:");
+  }
+
+  invalidateCategories(): void {
+    this.invalidatePattern("categories:");
+  }
+}
+
+export const cacheService = new CacheService();

--- a/apps/api/src/core/middleware/cacheHeaders.ts
+++ b/apps/api/src/core/middleware/cacheHeaders.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from "express";
+
+type CacheHeaderOptions = {
+  maxAge: number;
+  staleWhileRevalidate?: number;
+};
+
+export function cacheHeaders(options: CacheHeaderOptions) {
+  const { maxAge, staleWhileRevalidate = 0 } = options;
+
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const directives = [`public`, `max-age=${maxAge}`];
+    if (staleWhileRevalidate > 0) {
+      directives.push(`stale-while-revalidate=${staleWhileRevalidate}`);
+    }
+    res.setHeader("Cache-Control", directives.join(", "));
+    next();
+  };
+}

--- a/apps/api/src/modules/bet/controllers/BetController.ts
+++ b/apps/api/src/modules/bet/controllers/BetController.ts
@@ -6,6 +6,11 @@ import {
   UpdateBetInput,
 } from "../../../core/validation/ValidationSchemas";
 import { BetWithOdds } from "../repositories/BetRepository";
+import {
+  toBetDetail,
+  toBetListItem,
+  toBetListItems,
+} from "../mappers/bet.mapper";
 
 export class BetController extends BaseController<
   BetWithOdds,
@@ -24,7 +29,12 @@ export class BetController extends BaseController<
     try {
       const params = this.parsePaginationParams(req);
       const result = await this.betService.findAll(params);
-      this.sendSuccess(res, result, 200, "Bets retrieved successfully");
+      this.sendSuccess(
+        res,
+        { ...result, data: toBetListItems(result.data) },
+        200,
+        "Bets retrieved successfully",
+      );
     } catch (error) {
       this.handleError(error as Error, res, next);
     }
@@ -39,7 +49,7 @@ export class BetController extends BaseController<
       const id = this.parseId(req);
       const bet = await this.betService.findById(id);
 
-      this.sendSuccess(res, { bet }, 200, "Bet retrieved successfully");
+      this.sendSuccess(res, { bet: toBetDetail(bet) }, 200, "Bet retrieved successfully");
     } catch (error) {
       this.handleError(error as Error, res, next);
     }
@@ -50,7 +60,12 @@ export class BetController extends BaseController<
       const betData = req.body as CreateBetInput;
       const newBet = await this.betService.create(betData);
 
-      this.sendSuccess(res, { bet: newBet }, 201, "Bet created successfully");
+      this.sendSuccess(
+        res,
+        { bet: toBetListItem(newBet) },
+        201,
+        "Bet created successfully",
+      );
     } catch (error) {
       this.handleError(error as Error, res, next);
     }
@@ -64,7 +79,7 @@ export class BetController extends BaseController<
 
       this.sendSuccess(
         res,
-        { bet: updatedBet },
+        { bet: toBetListItem(updatedBet) },
         200,
         "Bet updated successfully",
       );
@@ -94,7 +109,7 @@ export class BetController extends BaseController<
       const bets = await this.betService.findByStatus(status);
       this.sendSuccess(
         res,
-        { data: bets },
+        { data: toBetListItems(bets) },
         200,
         `Bets with status '${status}' retrieved successfully`,
       );
@@ -113,7 +128,7 @@ export class BetController extends BaseController<
       const bets = await this.betService.findByCategory(categoryId);
       this.sendSuccess(
         res,
-        { data: bets },
+        { data: toBetListItems(bets) },
         200,
         "Bets by category retrieved successfully",
       );
@@ -131,7 +146,12 @@ export class BetController extends BaseController<
       const id = this.parseId(req);
       const closedBet = await this.betService.closeBet(id);
 
-      this.sendSuccess(res, { bet: closedBet }, 200, "Bet closed successfully");
+      this.sendSuccess(
+        res,
+        { bet: toBetListItem(closedBet) },
+        200,
+        "Bet closed successfully",
+      );
     } catch (error) {
       this.handleError(error as Error, res, next);
     }
@@ -155,7 +175,7 @@ export class BetController extends BaseController<
 
       this.sendSuccess(
         res,
-        { bet: resolvedBet },
+        { bet: toBetDetail(resolvedBet) },
         200,
         "Bet resolved successfully",
       );

--- a/apps/api/src/modules/bet/mappers/bet.mapper.ts
+++ b/apps/api/src/modules/bet/mappers/bet.mapper.ts
@@ -1,0 +1,43 @@
+import type { BetWithOdds } from "../repositories/BetRepository";
+import type { BetDetail, BetListItem } from "@sarradabet/types";
+
+export function toBetListItem(bet: BetWithOdds): BetListItem {
+  return {
+    id: bet.id,
+    title: bet.title,
+    description: bet.description,
+    status: bet.status,
+    categoryId: bet.categoryId,
+    category: bet.category,
+    totalVotes: bet.totalVotes,
+    createdAt: bet.createdAt,
+    odds: bet.odds.map(({ id, title, value, totalVotes }) => ({
+      id,
+      title,
+      value,
+      totalVotes,
+    })),
+  };
+}
+
+export function toBetDetail(bet: BetWithOdds): BetDetail {
+  return {
+    ...toBetListItem(bet),
+    updatedAt: bet.updatedAt,
+    resolvedAt: bet.resolvedAt,
+    odds: bet.odds.map(
+      ({ id, title, value, totalVotes, result, betId }) => ({
+        id,
+        title,
+        value,
+        totalVotes,
+        result,
+        betId,
+      }),
+    ),
+  };
+}
+
+export function toBetListItems(bets: BetWithOdds[]): BetListItem[] {
+  return bets.map(toBetListItem);
+}

--- a/apps/api/src/modules/bet/services/BetService.ts
+++ b/apps/api/src/modules/bet/services/BetService.ts
@@ -13,6 +13,9 @@ import {
   ConflictError,
   BadRequestError,
 } from "../../../core/errors/AppError";
+import { emitBetCreated, emitBetUpdated } from "../../../realtime/emitter";
+import { toBetListItem } from "../mappers/bet.mapper";
+import { cacheService } from "../../../core/cache/CacheService";
 
 export class BetService extends BaseService<
   BetWithOdds,
@@ -39,11 +42,22 @@ export class BetService extends BaseService<
   async findById(id: number): Promise<BetWithOdds> {
     this.validateId(id);
 
+    if (process.env.NODE_ENV !== "test") {
+      const cacheKey = `bet:${id}`;
+      const cached = cacheService.get<BetWithOdds>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+
     const bet = await this.betRepository.findUnique({ id });
     if (!bet) {
       throw new NotFoundError("Bet", id);
     }
 
+    if (process.env.NODE_ENV !== "test") {
+      cacheService.set(`bet:${id}`, bet, 30);
+    }
     return bet;
   }
 
@@ -57,9 +71,13 @@ export class BetService extends BaseService<
     await this.validateCategoryExists(data.categoryId);
 
     const bet = await this.betRepository.create(data);
-    return this.executeBusinessLogic
+    const result = this.executeBusinessLogic
       ? await this.executeBusinessLogic(bet)
       : bet;
+
+    cacheService.invalidatePattern("bets:");
+    emitBetCreated(toBetListItem(result));
+    return result;
   }
 
   async update(id: number, data: UpdateBetInput): Promise<BetWithOdds> {
@@ -81,9 +99,12 @@ export class BetService extends BaseService<
     }
 
     const updatedBet = await this.betRepository.update({ id }, data);
-    return this.executeBusinessLogic
+    const result = this.executeBusinessLogic
       ? await this.executeBusinessLogic(updatedBet)
       : updatedBet;
+
+    this.publishBetUpdate(result);
+    return result;
   }
 
   async delete(id: number): Promise<void> {
@@ -99,9 +120,22 @@ export class BetService extends BaseService<
     }
 
     await this.betRepository.delete({ id });
+    cacheService.invalidateBet(id);
   }
 
   async findByStatus(status: string): Promise<BetWithOdds[]> {
+    if (status === "resolved" && process.env.NODE_ENV !== "test") {
+      const cacheKey = `bets:status:resolved`;
+      const cached = cacheService.get<BetWithOdds[]>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const bets = await this.betRepository.findByStatus(status);
+      cacheService.set(cacheKey, bets, 120);
+      return bets;
+    }
+
     return this.betRepository.findByStatus(status);
   }
 
@@ -163,7 +197,15 @@ export class BetService extends BaseService<
       });
     });
 
-    return this.findById(id);
+    const resolved = await this.findById(id);
+    this.publishBetUpdate(resolved);
+    return resolved;
+  }
+
+  private publishBetUpdate(bet: BetWithOdds): void {
+    cacheService.invalidateBet(bet.id);
+    cacheService.del("bets:status:resolved");
+    emitBetUpdated(toBetListItem(bet));
   }
 
   private validateOddsValues(odds: { value: number }[]): void {

--- a/apps/api/src/modules/category/services/CategoryService.ts
+++ b/apps/api/src/modules/category/services/CategoryService.ts
@@ -12,6 +12,7 @@ import {
   PaginatedResult,
 } from "../../../core/interfaces/IRepository";
 import { NotFoundError, ConflictError } from "../../../core/errors/AppError";
+import { cacheService } from "../../../core/cache/CacheService";
 
 export class CategoryService extends BaseService<
   CategoryWithStats,
@@ -25,14 +26,28 @@ export class CategoryService extends BaseService<
   async findAll(
     params?: PaginationParams,
   ): Promise<PaginatedResult<CategoryWithStats>> {
-    return this.categoryRepository.findManyWithPagination(
-      params || {
-        page: 1,
-        limit: 10,
-        sortBy: "createdAt",
-        sortOrder: "desc",
-      },
-    );
+    const resolvedParams = params || {
+      page: 1,
+      limit: 10,
+      sortBy: "createdAt",
+      sortOrder: "desc" as const,
+    };
+
+    if (process.env.NODE_ENV !== "test") {
+      const cacheKey = `categories:list:${JSON.stringify(resolvedParams)}`;
+      const cached =
+        cacheService.get<PaginatedResult<CategoryWithStats>>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const result =
+        await this.categoryRepository.findManyWithPagination(resolvedParams);
+      cacheService.set(cacheKey, result, 300);
+      return result;
+    }
+
+    return this.categoryRepository.findManyWithPagination(resolvedParams);
   }
 
   async findById(id: number): Promise<CategoryWithStats> {
@@ -58,6 +73,7 @@ export class CategoryService extends BaseService<
     }
 
     const category = await this.categoryRepository.create(data);
+    cacheService.invalidateCategories();
     return await this.executeBusinessLogic(category);
   }
 
@@ -83,6 +99,7 @@ export class CategoryService extends BaseService<
     }
 
     const updatedCategory = await this.categoryRepository.update({ id }, data);
+    cacheService.invalidateCategories();
     return await this.executeBusinessLogic(updatedCategory);
   }
 
@@ -98,6 +115,7 @@ export class CategoryService extends BaseService<
     }
 
     await this.categoryRepository.delete({ id });
+    cacheService.invalidateCategories();
   }
 
   async searchByTitle(searchTerm: string): Promise<CategoryWithStats[]> {

--- a/apps/api/src/realtime/emitter.ts
+++ b/apps/api/src/realtime/emitter.ts
@@ -1,0 +1,33 @@
+import {
+  RealtimeEvents,
+  type BetListItem,
+  type RealtimeEventName,
+  type RealtimePayloadMap,
+  type VoteCreatedPayload,
+} from "@sarradabet/types";
+import { getSocketServer } from "./socket";
+import { logger } from "../utils/logger";
+
+function emitEvent<E extends RealtimeEventName>(
+  event: E,
+  payload: RealtimePayloadMap[E],
+): void {
+  const io = getSocketServer();
+  if (!io) {
+    logger.warn(`Socket.io not initialized; skipped emit ${event}`);
+    return;
+  }
+  io.emit(event, payload);
+}
+
+export function emitVoteCreated(payload: VoteCreatedPayload): void {
+  emitEvent(RealtimeEvents.VOTE_CREATED, payload);
+}
+
+export function emitBetCreated(payload: BetListItem): void {
+  emitEvent(RealtimeEvents.BET_CREATED, payload);
+}
+
+export function emitBetUpdated(payload: BetListItem): void {
+  emitEvent(RealtimeEvents.BET_UPDATED, payload);
+}

--- a/apps/api/src/realtime/socket.ts
+++ b/apps/api/src/realtime/socket.ts
@@ -1,0 +1,43 @@
+import type { Server as HttpServer } from "http";
+import { Server } from "socket.io";
+import { config } from "../config/env";
+import { logger } from "../utils/logger";
+
+let io: Server | null = null;
+
+function getAllowedOrigins(): string[] {
+  return config.CORS_ORIGINS.split(",").map((origin) => origin.trim());
+}
+
+export function initSocketServer(httpServer: HttpServer): Server {
+  io = new Server(httpServer, {
+    cors: {
+      origin: getAllowedOrigins(),
+      credentials: true,
+      methods: ["GET", "POST"],
+    },
+    path: "/socket.io",
+  });
+
+  io.on("connection", (socket) => {
+    logger.info(`Socket connected: ${socket.id}`);
+
+    socket.on("disconnect", () => {
+      logger.info(`Socket disconnected: ${socket.id}`);
+    });
+  });
+
+  logger.info("Socket.io server initialized");
+  return io;
+}
+
+export function getSocketServer(): Server | null {
+  return io;
+}
+
+export function closeSocketServer(): void {
+  if (io) {
+    io.close();
+    io = null;
+  }
+}

--- a/apps/api/src/repositories/bet.repository.ts
+++ b/apps/api/src/repositories/bet.repository.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
 import { UpdateBetDTO, CreateBetDTO } from "../types/bet.types";
-
-const prisma = new PrismaClient();
+import { prisma } from "../config/db";
 
 export const getAllBetsFromRepository = async (
   page: number = 1,

--- a/apps/api/src/repositories/category.repository.ts
+++ b/apps/api/src/repositories/category.repository.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
 import { CreateCategoryDTO, UpdateCategoryDTO } from "../types/category.types";
-
-const prisma = new PrismaClient();
+import { prisma } from "../config/db";
 
 export const getAllCategoriesFromRepository = async (
   page: number = 1,

--- a/apps/api/src/repositories/odd.repository.ts
+++ b/apps/api/src/repositories/odd.repository.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "../config/db";
 
 export const findAllWithVotes = async () => {
   return prisma.odd.findMany({

--- a/apps/api/src/repositories/vote.repository.ts
+++ b/apps/api/src/repositories/vote.repository.ts
@@ -1,14 +1,58 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../config/db";
 import { CreateVoteDTO } from "../types/vote.types";
+import { NotFoundError } from "../core/errors/AppError";
 
-const prisma = new PrismaClient();
+export type VoteWithOddsUpdate = {
+  vote: { id: number; oddId: number; createdAt: Date };
+  betId: number;
+  oddId: number;
+  odds: { id: number; totalVotes: number }[];
+  totalVotes: number;
+};
 
-export const createVoteWithOdds = async (data: CreateVoteDTO) => {
-  return prisma.$transaction(async (tx: any) => {
-    return tx.vote.create({
-      data: {
-        oddId: data.oddId,
+export const createVoteWithOdds = async (
+  data: CreateVoteDTO,
+): Promise<VoteWithOddsUpdate> => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    const odd = await tx.odd.findUnique({
+      where: { id: data.oddId },
+      select: { id: true, betId: true },
+    });
+
+    if (!odd) {
+      throw new NotFoundError("Odd", data.oddId);
+    }
+
+    const vote = await tx.vote.create({
+      data: { oddId: data.oddId },
+    });
+
+    const oddsWithCounts = await tx.odd.findMany({
+      where: { betId: odd.betId },
+      include: {
+        _count: {
+          select: { votes: true },
+        },
       },
     });
+
+    const odds = oddsWithCounts.map((o: (typeof oddsWithCounts)[number]) => ({
+      id: o.id,
+      totalVotes: o._count.votes,
+    }));
+
+    const totalVotes = odds.reduce(
+      (sum: number, o: (typeof odds)[number]) => sum + o.totalVotes,
+      0,
+    );
+
+    return {
+      vote,
+      betId: odd.betId,
+      oddId: data.oddId,
+      odds,
+      totalVotes,
+    };
   });
 };

--- a/apps/api/src/routes/vote.routes.ts
+++ b/apps/api/src/routes/vote.routes.ts
@@ -1,10 +1,10 @@
 import { Router } from "express";
-import { createVote } from "../controllers/vote.controller";
+import { createVoteHandler } from "../controllers/vote.controller";
 import { validateRequest } from "../utils/validator";
 import { CreateVoteSchema } from "../types/vote.types";
 
 const router = Router();
 
-router.post("/", validateRequest(CreateVoteSchema, "body"), createVote);
+router.post("/", validateRequest(CreateVoteSchema, "body"), createVoteHandler);
 
 export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,8 +1,10 @@
+import { createServer } from "http";
 import { app } from "./app";
 import { config } from "./config/env";
 import { logger } from "./utils/logger";
 import { prisma } from "./config/db";
 import { initializeConsul } from "./config/consul";
+import { initSocketServer, closeSocketServer } from "./realtime/socket";
 
 const checkDatabaseConnection = async () => {
   try {
@@ -20,16 +22,19 @@ const startServer = async () => {
   try {
     await checkDatabaseConnection();
 
-    // Initialize Consul service registration
     await initializeConsul();
 
-    const server = app.listen(PORT, () => {
+    const httpServer = createServer(app);
+    initSocketServer(httpServer);
+
+    httpServer.listen(PORT, () => {
       logger.info(`Server running in ${config.NODE_ENV} mode on port ${PORT}`);
     });
 
     const shutdown = async () => {
       logger.info("Shutting down server...");
-      server.close(async () => {
+      closeSocketServer();
+      httpServer.close(async () => {
         await prisma.$disconnect();
         logger.info("Server and database connections closed");
         process.exit(0);

--- a/apps/api/src/services/vote.service.ts
+++ b/apps/api/src/services/vote.service.ts
@@ -1,6 +1,25 @@
 import { CreateVoteDTO } from "../types/vote.types";
-import * as voteRepository from "../repositories/vote.repository";
+import {
+  createVoteWithOdds,
+  VoteWithOddsUpdate,
+} from "../repositories/vote.repository";
+import { emitVoteCreated } from "../realtime/emitter";
+import { cacheService } from "../core/cache/CacheService";
 
-export const createVote = async (data: CreateVoteDTO) => {
-  return voteRepository.createVoteWithOdds(data);
+export const createVote = async (
+  data: CreateVoteDTO,
+): Promise<VoteWithOddsUpdate> => {
+  const result = await createVoteWithOdds(data);
+
+  cacheService.invalidateBet(result.betId);
+  cacheService.invalidatePattern("bets:");
+
+  emitVoteCreated({
+    betId: result.betId,
+    oddId: result.oddId,
+    odds: result.odds,
+    totalVotes: result.totalVotes,
+  });
+
+  return result;
 };

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env: cp apps/web/.env.example apps/web/.env
+
+# Express API (must match apps/api PORT)
+VITE_API_URL=http://localhost:8000
+
+# Optional — used when VITE_API_URL is unset
+# VITE_API_GATEWAY_URL=http://localhost:8000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,15 +20,15 @@
     "@headlessui/react": "^2.2.0",
     "@sarradabet/types": "*",
     "@sarradahub/design-system": "file:../../../platform/design-system",
-    "axios": "^1.13.2",
+    "axios": "^1.18.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "didyoumean": "^1.2.2",
     "lucide-react": "^0.525.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.9.6",
-    "react-router-dom": "^7.9.6",
+    "react-router": "^7.17.0",
+    "react-router-dom": "^7.17.0",
     "set-cookie-parser": "^2.7.2",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1"
@@ -42,7 +42,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.6",
     "autoprefixer": "^10.4.21",
     "dlv": "^1.1.3",
     "eslint": "^9.39.1",
@@ -51,7 +51,6 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^15.15.0",
-    "happy-dom": "^17.6.3",
     "jsdom": "^27.2.0",
     "object-hash": "^3.0.0",
     "postcss": "^8.5.3",
@@ -64,9 +63,9 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.47.0",
     "vite": "^7.1.9",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.6"
   },
   "overrides": {
-    "minimatch": "^3.1.2"
+    "minimatch": "^3.1.5"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",
+    "@sarradabet/types": "*",
     "@sarradahub/design-system": "file:../../../platform/design-system",
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
@@ -29,6 +30,7 @@
     "react-router": "^7.9.6",
     "react-router-dom": "^7.9.6",
     "set-cookie-parser": "^2.7.2",
+    "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,19 +1,39 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router";
 import HomePage from "./pages/HomePage";
-import AdminLogin from "./pages/AdminLogin";
-import AdminDashboard from "./pages/AdminDashboard";
+import { RealtimeProvider } from "./context/RealtimeProvider";
+import PageSkeleton from "./components/ui/PageSkeleton";
 import "./App.css";
+
+const AdminLogin = lazy(() => import("./pages/AdminLogin"));
+const AdminDashboard = lazy(() => import("./pages/AdminDashboard"));
 
 function App() {
   return (
     <Router>
-      <main>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/admin/login" element={<AdminLogin />} />
-          <Route path="/admin/dashboard" element={<AdminDashboard />} />
-        </Routes>
-      </main>
+      <RealtimeProvider>
+        <main>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route
+              path="/admin/login"
+              element={
+                <Suspense fallback={<PageSkeleton />}>
+                  <AdminLogin />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/admin/dashboard"
+              element={
+                <Suspense fallback={<PageSkeleton />}>
+                  <AdminDashboard />
+                </Suspense>
+              }
+            />
+          </Routes>
+        </main>
+      </RealtimeProvider>
     </Router>
   );
 }

--- a/apps/web/src/components/BetCard.tsx
+++ b/apps/web/src/components/BetCard.tsx
@@ -1,65 +1,66 @@
-import { Bet } from "../types/bet";
+import { useState, useEffect, useCallback } from "react";
+import { RealtimeEvents, type VoteCreatedPayload } from "@sarradabet/types";
 import { format } from "date-fns";
 import OddsList from "./OddsList";
-import { useState, useEffect, useCallback } from "react";
-import { betService } from "../services/BetService";
-import { categoryService } from "../services/CategoryService";
+import { useSocketEvent } from "../core/hooks/useSocket";
+import { Bet } from "../types/bet";
 
 interface BetCardProps {
   bet: Bet;
-  onVoteCreated?: () => void;
 }
 
-const BetCard = ({ bet, onVoteCreated }: BetCardProps) => {
+const BetCard = ({ bet }: BetCardProps) => {
   const [oddsData, setOddsData] = useState(bet.odds);
-  const [categoryData, setCategoryData] = useState<{
-    id: number;
-    title: string;
-  } | null>(null);
+  const [totalVotes, setTotalVotes] = useState(bet.totalVotes ?? 0);
 
   const formattedDate = format(new Date(bet.createdAt), "dd/MM/yyyy");
+  const categoryTitle = bet.category?.title;
 
   useEffect(() => {
     setOddsData(bet.odds);
-  }, [bet.odds]);
+    setTotalVotes(bet.totalVotes ?? 0);
+  }, [bet.odds, bet.totalVotes]);
 
-  const fetchUpdatedOdds = async () => {
-    try {
-      const response = await betService.getById(bet.id);
-      setOddsData(response.data.odds);
-      onVoteCreated?.();
-    } catch (error) {
-      console.error("Error updating odds:", error);
-    }
-  };
+  useSocketEvent<VoteCreatedPayload>(RealtimeEvents.VOTE_CREATED, (payload) => {
+    if (payload.betId !== bet.id) return;
 
-  const fetchCategory = useCallback(async () => {
-    if (typeof bet.categoryId !== "number") return;
+    setTotalVotes(payload.totalVotes);
+    setOddsData((current) =>
+      current.map((odd) => {
+        const updated = payload.odds.find((o) => o.id === odd.id);
+        return updated ? { ...odd, totalVotes: updated.totalVotes } : odd;
+      }),
+    );
+  });
 
-    try {
-      const category = await categoryService.getById(bet.categoryId);
-      setCategoryData(category.data);
-    } catch (error) {
-      console.error("Error getting category:", error);
-      setCategoryData(null);
-    }
-  }, [bet.categoryId]);
+  const handleOptimisticVote = useCallback((oddId: number) => {
+    setOddsData((current) =>
+      current.map((odd) =>
+        odd.id === oddId
+          ? { ...odd, totalVotes: odd.totalVotes + 1 }
+          : odd,
+      ),
+    );
+    setTotalVotes((current) => current + 1);
+  }, []);
 
-  useEffect(() => {
-    if (bet.categoryId) {
-      fetchCategory();
-    }
-  }, [bet.categoryId, fetchCategory]);
+  const handleVoteRollback = useCallback(
+    (_oddId: number, previousOdds: typeof bet.odds, previousTotal: number) => {
+      setOddsData(previousOdds);
+      setTotalVotes(previousTotal);
+    },
+    [],
+  );
 
   return (
-    <div className="group w-full bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl p-6 border border-gray-700 hover:border-yellow-400/50 transition-all duration-300 shadow-lg hover:shadow-2xl hover:shadow-yellow-500/10 transform hover:-translate-y-1">
-      <div className="flex justify-between items-start mb-4">
-        <h3 className="text-lg font-bold text-white pr-2 leading-tight group-hover:text-yellow-400 transition-colors">
+    <div className="group w-full min-w-0 bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl p-4 sm:p-5 lg:p-6 border border-gray-700 hover:border-yellow-400/50 transition-all duration-300 shadow-lg hover:shadow-2xl hover:shadow-yellow-500/10 transform hover:-translate-y-1">
+      <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-start mb-4">
+        <h3 className="min-w-0 flex-1 text-base sm:text-lg font-bold text-white leading-tight line-clamp-2 group-hover:text-yellow-400 transition-colors">
           {bet.title}
         </h3>
-        {categoryData && (
-          <span className="bg-gradient-to-r from-yellow-400 to-orange-500 text-black px-3 py-1 rounded-full text-xs font-semibold shrink-0 shadow-md">
-            {categoryData.title}
+        {categoryTitle && (
+          <span className="bg-gradient-to-r from-yellow-400 to-orange-500 text-black px-3 py-1 rounded-full text-xs font-semibold shrink-0 self-start shadow-md max-w-full truncate">
+            {categoryTitle}
           </span>
         )}
       </div>
@@ -73,11 +74,15 @@ const BetCard = ({ bet, onVoteCreated }: BetCardProps) => {
       )}
 
       <div className="mb-6">
-        <OddsList odds={oddsData} onVoteCreated={fetchUpdatedOdds} />
+        <OddsList
+          odds={oddsData}
+          onOptimisticVote={handleOptimisticVote}
+          onVoteRollback={handleVoteRollback}
+        />
       </div>
 
-      <div className="flex justify-between items-center pt-4 border-t border-gray-700">
-        <div className="flex items-center gap-4 text-sm">
+      <div className="flex flex-col gap-3 pt-4 border-t border-gray-700 sm:flex-row sm:flex-wrap sm:justify-between sm:items-center">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm min-w-0">
           <div className="flex items-center gap-2 text-gray-400">
             <svg
               className="w-4 h-4"
@@ -92,7 +97,7 @@ const BetCard = ({ bet, onVoteCreated }: BetCardProps) => {
                 d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
               />
             </svg>
-            <span>{bet.totalVotes ?? 0} votos</span>
+            <span>{totalVotes} votos</span>
           </div>
           <div className="flex items-center gap-2 text-gray-400">
             <svg
@@ -112,7 +117,7 @@ const BetCard = ({ bet, onVoteCreated }: BetCardProps) => {
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 shrink-0">
           <div
             className={`w-2 h-2 rounded-full ${
               bet.status === "open"

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { useState } from "react";
 import CreateCategoryModal from "./CreateCategoryModal";
 import { Button } from "./ui/Button";
-import { Plus, Settings } from "lucide-react";
+import { Plus, Settings } from "@sarradahub/design-system";
 
 interface NavigationProps {
   onOpenCreateModal: () => void;

--- a/apps/web/src/components/OddsList.tsx
+++ b/apps/web/src/components/OddsList.tsx
@@ -1,18 +1,43 @@
+import { useState } from "react";
 import { Odd } from "../types/odd";
 import { voteService } from "../services/VoteService";
 
 interface OddsListProps {
   odds: Odd[];
-  onVoteCreated?: () => void;
+  onOptimisticVote?: (oddId: number) => void;
+  onVoteRollback?: (
+    oddId: number,
+    previousOdds: Odd[],
+    previousTotal: number,
+  ) => void;
 }
 
-const OddsList = ({ odds, onVoteCreated }: OddsListProps) => {
+const OddsList = ({
+  odds,
+  onOptimisticVote,
+  onVoteRollback,
+}: OddsListProps) => {
+  const [votingOddId, setVotingOddId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
   const handleCreateVote = async (oddId: number) => {
+    if (votingOddId !== null) return;
+
+    const previousOdds = odds.map((odd) => ({ ...odd }));
+    const previousTotal = odds.reduce((sum, odd) => sum + odd.totalVotes, 0);
+
+    setError(null);
+    setVotingOddId(oddId);
+    onOptimisticVote?.(oddId);
+
     try {
       await voteService.create({ oddId });
-      onVoteCreated?.();
-    } catch (error) {
-      console.error("Erro ao criar voto:", error);
+    } catch (voteError) {
+      console.error("Erro ao criar voto:", voteError);
+      onVoteRollback?.(oddId, previousOdds, previousTotal);
+      setError("Não foi possível registrar seu voto. Tente novamente.");
+    } finally {
+      setVotingOddId(null);
     }
   };
 
@@ -36,55 +61,33 @@ const OddsList = ({ odds, onVoteCreated }: OddsListProps) => {
           Opções de Aposta
         </span>
       </div>
+
+      {error && (
+        <p className="text-sm text-red-400 mb-3" role="alert">
+          {error}
+        </p>
+      )}
+
       <div className="grid grid-cols-1 gap-3">
         {odds.map((odd) => (
           <button
             key={odd.id}
             onClick={() => handleCreateVote(odd.id)}
-            className="group flex justify-between items-center bg-gradient-to-r from-gray-700 to-gray-800 p-4 rounded-xl hover:from-gray-600 hover:to-gray-700 transition-all duration-200 border border-gray-600 hover:border-yellow-400/50 shadow-md hover:shadow-lg transform hover:-translate-y-0.5"
+            disabled={votingOddId !== null}
+            className="group w-full min-w-0 overflow-hidden flex flex-col gap-2 bg-gradient-to-r from-gray-700 to-gray-800 p-3 sm:p-4 rounded-xl hover:from-gray-600 hover:to-gray-700 transition-all duration-200 border border-gray-600 hover:border-yellow-400/50 shadow-md hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            <div className="flex-1 text-left">
-              <span className="text-white font-medium group-hover:text-yellow-400 transition-colors">
+            <div className="min-w-0 w-full text-left">
+              <span className="block truncate text-white font-medium group-hover:text-yellow-400 transition-colors">
                 {odd.title}
               </span>
             </div>
-            <div className="flex items-center gap-3 ml-4">
-              <div className="flex items-center gap-2">
-                <svg
-                  className="w-4 h-4 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                  />
-                </svg>
-                <span className="bg-blue-600 text-white px-3 py-1 rounded-lg text-sm font-semibold min-w-[60px] text-center">
-                  {odd.totalVotes}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <svg
-                  className="w-4 h-4 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
-                  />
-                </svg>
-                <span className="bg-gradient-to-r from-green-600 to-green-500 text-white px-3 py-1 rounded-lg text-sm font-bold min-w-[70px] text-center shadow-md">
-                  {odd.value}x
-                </span>
-              </div>
+            <div className="flex items-center justify-end gap-2 shrink-0 w-full">
+              <span className="bg-blue-600 text-white px-2.5 py-1 rounded-lg text-xs sm:text-sm font-semibold text-center">
+                {odd.totalVotes}
+              </span>
+              <span className="bg-gradient-to-r from-green-600 to-green-500 text-white px-2.5 py-1 rounded-lg text-xs sm:text-sm font-bold text-center shadow-md">
+                {odd.value}x
+              </span>
             </div>
           </button>
         ))}

--- a/apps/web/src/components/ui/BetCardSkeleton.tsx
+++ b/apps/web/src/components/ui/BetCardSkeleton.tsx
@@ -1,0 +1,20 @@
+const BetCardSkeleton = () => (
+  <div className="w-full bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl p-6 border border-gray-700 animate-pulse">
+    <div className="flex justify-between items-start mb-4">
+      <div className="h-5 bg-gray-700 rounded w-3/4" />
+      <div className="h-6 bg-gray-700 rounded-full w-20" />
+    </div>
+    <div className="h-4 bg-gray-700 rounded w-full mb-2" />
+    <div className="h-4 bg-gray-700 rounded w-2/3 mb-6" />
+    <div className="space-y-3 mb-6">
+      <div className="h-14 bg-gray-700 rounded-xl" />
+      <div className="h-14 bg-gray-700 rounded-xl" />
+    </div>
+    <div className="flex justify-between pt-4 border-t border-gray-700">
+      <div className="h-4 bg-gray-700 rounded w-24" />
+      <div className="h-4 bg-gray-700 rounded w-16" />
+    </div>
+  </div>
+);
+
+export default BetCardSkeleton;

--- a/apps/web/src/components/ui/PageSkeleton.tsx
+++ b/apps/web/src/components/ui/PageSkeleton.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "./LoadingSpinner";
+
+const PageSkeleton = () => (
+  <div className="min-h-screen bg-gradient-to-br from-neutral-900 via-neutral-800 to-neutral-900 flex items-center justify-center">
+    <LoadingSpinner size="lg" text="Carregando..." />
+  </div>
+);
+
+export default PageSkeleton;

--- a/apps/web/src/context/RealtimeProvider.tsx
+++ b/apps/web/src/context/RealtimeProvider.tsx
@@ -1,0 +1,80 @@
+import {
+  RealtimeEvents,
+  type BetListItem,
+  type VoteCreatedPayload,
+} from "@sarradabet/types";
+import { useSocketEvent } from "../core/hooks/useSocket";
+import { queryCache } from "../core/hooks/useQueryCache";
+import { Bet } from "../types/bet";
+
+type PaginatedBetsResponse = {
+  data?: Bet[];
+  meta?: unknown;
+};
+
+function patchBetsCache(
+  updater: (bets: Bet[]) => Bet[] | null,
+): void {
+  queryCache.updateByPrefix<PaginatedBetsResponse | Bet[]>("bets-", (_key, data) => {
+    if (Array.isArray(data)) {
+      const updated = updater(data);
+      return updated;
+    }
+
+    if (data && typeof data === "object" && "data" in data && Array.isArray(data.data)) {
+      const updatedList = updater(data.data);
+      if (updatedList === null) {
+        return null;
+      }
+      return { ...data, data: updatedList };
+    }
+
+    return data;
+  });
+}
+
+function handleVoteCreated(payload: VoteCreatedPayload): void {
+  patchBetsCache((bets) =>
+    bets.map((bet) => {
+      if (bet.id !== payload.betId) {
+        return bet;
+      }
+
+      return {
+        ...bet,
+        totalVotes: payload.totalVotes,
+        odds: bet.odds.map((odd) => {
+          const updated = payload.odds.find((o) => o.id === odd.id);
+          return updated ? { ...odd, totalVotes: updated.totalVotes } : odd;
+        }),
+      };
+    }),
+  );
+}
+
+function handleBetUpsert(payload: BetListItem): void {
+  patchBetsCache((bets) => {
+    const existingIndex = bets.findIndex((bet) => bet.id === payload.id);
+    const bet = payload as Bet;
+
+    if (existingIndex >= 0) {
+      const next = [...bets];
+      next[existingIndex] = { ...next[existingIndex], ...bet };
+      return next;
+    }
+
+    return [bet, ...bets];
+  });
+}
+
+export function RealtimeProvider({ children }: { children: React.ReactNode }) {
+  useSocketEvent<VoteCreatedPayload>(
+    RealtimeEvents.VOTE_CREATED,
+    handleVoteCreated,
+  );
+
+  useSocketEvent<BetListItem>(RealtimeEvents.BET_CREATED, handleBetUpsert);
+  useSocketEvent<BetListItem>(RealtimeEvents.BET_UPDATED, handleBetUpsert);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/core/base/BaseService.ts
+++ b/apps/web/src/core/base/BaseService.ts
@@ -2,6 +2,14 @@ import axios, { AxiosInstance, AxiosResponse } from "axios";
 import { IApiService, ApiResponse, ApiError } from "../interfaces/IService";
 import { requestDeduplicator } from "../utils/requestDeduplicator";
 
+function headerValue(
+  headers: AxiosResponse["headers"],
+  key: string,
+): string {
+  const value = headers[key];
+  return typeof value === "string" ? value : "";
+}
+
 export abstract class BaseService<T, CreateInput, UpdateInput>
   implements IApiService<T, CreateInput, UpdateInput>
 {
@@ -45,7 +53,7 @@ export abstract class BaseService<T, CreateInput, UpdateInput>
 
     this.api.interceptors.response.use(
       (response: AxiosResponse) => {
-        const contentType = response.headers["content-type"] || "";
+        const contentType = headerValue(response.headers, "content-type");
         if (
           contentType.includes("text/html") &&
           typeof response.data === "string" &&
@@ -72,7 +80,10 @@ export abstract class BaseService<T, CreateInput, UpdateInput>
           error.message?.includes("exceeded");
 
         const isHtmlResponse =
-          error.response?.headers?.["content-type"]?.includes("text/html") ||
+          headerValue(
+            error.response?.headers ?? {},
+            "content-type",
+          ).includes("text/html") ||
           (typeof error.response?.data === "string" &&
             error.response?.data?.includes("<!doctype html>"));
 

--- a/apps/web/src/core/hooks/useMutation.ts
+++ b/apps/web/src/core/hooks/useMutation.ts
@@ -1,7 +1,13 @@
 import { useState, useCallback } from "react";
 import { ApiResponse, ApiError } from "../interfaces/IService";
 
-export interface UseMutationOptions<TData, TVariables> {
+export interface UseMutationOptions<TData, TVariables, TContext = unknown> {
+  onMutate?: (variables: TVariables) => TContext | void | Promise<TContext | void>;
+  onRollback?: (
+    context: TContext,
+    error: ApiError,
+    variables: TVariables,
+  ) => void;
   onSuccess?: (data: TData, variables: TVariables) => void;
   onError?: (error: ApiError, variables: TVariables) => void;
   onSettled?: (
@@ -24,11 +30,11 @@ export interface UseMutationResult<TData, TVariables> {
   isIdle: boolean;
 }
 
-export function useMutation<TData, TVariables>(
+export function useMutation<TData, TVariables, TContext = unknown>(
   mutationFn: (variables: TVariables) => Promise<ApiResponse<TData>>,
-  options: UseMutationOptions<TData, TVariables> = {},
+  options: UseMutationOptions<TData, TVariables, TContext> = {},
 ): UseMutationResult<TData, TVariables> {
-  const { onSuccess, onError, onSettled } = options;
+  const { onMutate, onRollback, onSuccess, onError, onSettled } = options;
 
   const [data, setData] = useState<TData | null>(null);
   const [loading, setLoading] = useState(false);
@@ -37,10 +43,14 @@ export function useMutation<TData, TVariables>(
 
   const mutate = useCallback(
     async (variables: TVariables): Promise<TData | null> => {
+      let context: TContext | void | undefined;
+
       try {
         setLoading(true);
         setError(null);
         setApiError(null);
+
+        context = await onMutate?.(variables);
 
         const response = await mutationFn(variables);
 
@@ -49,19 +59,23 @@ export function useMutation<TData, TVariables>(
           onSuccess?.(response.data, variables);
           onSettled?.(response.data, null, variables);
           return response.data;
-        } else {
-          const errorMessage = response.message || "Mutation failed";
-          const mutationError: ApiError = {
-            success: false,
-            message: errorMessage,
-          };
-
-          setError(errorMessage);
-          setApiError(mutationError);
-          onError?.(mutationError, variables);
-          onSettled?.(null, mutationError, variables);
-          return null;
         }
+
+        const errorMessage = response.message || "Mutation failed";
+        const mutationError: ApiError = {
+          success: false,
+          message: errorMessage,
+        };
+
+        if (context !== undefined && onRollback) {
+          onRollback(context as TContext, mutationError, variables);
+        }
+
+        setError(errorMessage);
+        setApiError(mutationError);
+        onError?.(mutationError, variables);
+        onSettled?.(null, mutationError, variables);
+        return null;
       } catch (err: unknown) {
         const e = err as { message?: string; errors?: ApiError["errors"] };
         const mutationError: ApiError = {
@@ -69,6 +83,10 @@ export function useMutation<TData, TVariables>(
           message: e?.message || "An unexpected error occurred",
           errors: e?.errors,
         };
+
+        if (context !== undefined && onRollback) {
+          onRollback(context as TContext, mutationError, variables);
+        }
 
         setError(mutationError.message);
         setApiError(mutationError);
@@ -79,7 +97,7 @@ export function useMutation<TData, TVariables>(
         setLoading(false);
       }
     },
-    [mutationFn, onSuccess, onError, onSettled],
+    [mutationFn, onMutate, onRollback, onSuccess, onError, onSettled],
   );
 
   const mutateAsync = useCallback(

--- a/apps/web/src/core/hooks/useQuery.ts
+++ b/apps/web/src/core/hooks/useQuery.ts
@@ -118,11 +118,14 @@ export function useQuery<T>(
     if (lastFetched && staleTime > 0) {
       const timer = setTimeout(() => {
         setIsStale(true);
+        if (enabled) {
+          void refetch();
+        }
       }, staleTime);
 
       return () => clearTimeout(timer);
     }
-  }, [lastFetched, staleTime]);
+  }, [lastFetched, staleTime, enabled, refetch]);
 
   return {
     data: api.data,

--- a/apps/web/src/core/hooks/useQueryCache.ts
+++ b/apps/web/src/core/hooks/useQueryCache.ts
@@ -75,6 +75,40 @@ class QueryCache {
     }
   }
 
+  keysMatching(prefix: string): string[] {
+    return Array.from(this.cache.keys()).filter((key) => key.startsWith(prefix));
+  }
+
+  getRaw<T>(key: string): T | null {
+    const cached = this.cache.get(key);
+    if (cached?.data !== undefined) {
+      return cached.data as T;
+    }
+    return null;
+  }
+
+  updateData<T>(key: string, updater: (data: T) => T): void {
+    const cached = this.cache.get(key);
+    if (cached?.data !== undefined) {
+      this.set(key, updater(cached.data as T));
+    }
+  }
+
+  updateByPrefix<T>(
+    prefix: string,
+    updater: (key: string, data: T) => T | null,
+  ): void {
+    for (const key of this.keysMatching(prefix)) {
+      const data = this.getRaw<T>(key);
+      if (data !== null) {
+        const updated = updater(key, data);
+        if (updated !== null) {
+          this.set(key, updated);
+        }
+      }
+    }
+  }
+
   cleanup() {
     const now = Date.now();
     for (const [key, value] of this.cache.entries()) {

--- a/apps/web/src/core/hooks/useSocket.ts
+++ b/apps/web/src/core/hooks/useSocket.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { io, Socket } from "socket.io-client";
+
+function getSocketUrl(): string {
+  const directApiUrl = import.meta.env.VITE_API_URL;
+  if (directApiUrl) {
+    return directApiUrl;
+  }
+
+  const apiGatewayUrl =
+    import.meta.env.VITE_API_GATEWAY_URL || "http://localhost:8000";
+  return apiGatewayUrl;
+}
+
+let sharedSocket: Socket | null = null;
+
+export function getSocket(): Socket {
+  if (!sharedSocket) {
+    sharedSocket = io(getSocketUrl(), {
+      path: "/socket.io",
+      transports: ["websocket", "polling"],
+      autoConnect: true,
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 1000,
+    });
+  }
+
+  return sharedSocket;
+}
+
+export function useSocketEvent<T>(
+  event: string,
+  handler: (payload: T) => void,
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const socket = getSocket();
+    const listener = (payload: T) => handlerRef.current(payload);
+    socket.on(event, listener);
+    return () => {
+      socket.off(event, listener);
+    };
+  }, [event]);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply bg-black text-white;
+    @apply bg-black text-white overflow-x-hidden;
   }
 
   /* Custom scrollbar */

--- a/apps/web/src/pages/AdminLogin.tsx
+++ b/apps/web/src/pages/AdminLogin.tsx
@@ -17,11 +17,7 @@ const AdminLogin: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
-  const API_GATEWAY_URL =
-    import.meta.env.VITE_API_GATEWAY_URL || "http://localhost";
-  const IDENTITY_SERVICE_URL =
-    import.meta.env.VITE_IDENTITY_SERVICE_URL ||
-    `${API_GATEWAY_URL}/api/v1/auth`;
+  const API_BASE_URL = import.meta.env.VITE_API_URL;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -29,14 +25,16 @@ const AdminLogin: React.FC = () => {
     setError(null);
 
     try {
-      const url = `${IDENTITY_SERVICE_URL}/login`;
+      const url = API_BASE_URL
+        ? `${API_BASE_URL}/api/v1/admin/login`
+        : "/api/v1/admin/login";
       const response = await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          email: formData.username, // Support both email and username
+          username: formData.username,
           password: formData.password,
         }),
       });

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { Category } from "../types/category";
 import Navigation from "../components/Navigation";
 import BetCard from "../components/BetCard";
 import CreateBetModal from "../components/CreateBetModal";
+import BetCardSkeleton from "../components/ui/BetCardSkeleton";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { Button } from "../components/ui/Button";
@@ -66,10 +67,6 @@ const HomePage: React.FC = () => {
   const handleBetCreated = useCallback(() => {
     refetchBets();
     setShowCreateModal(false);
-  }, [refetchBets]);
-
-  const handleVoteCreated = useCallback(() => {
-    refetchBets();
   }, [refetchBets]);
 
   const handleCategoryCreated = useCallback(() => {
@@ -149,8 +146,14 @@ const HomePage: React.FC = () => {
       />
 
       {isLoading ? (
-        <div className="bg-neutral-900 min-h-screen flex items-center justify-center">
-          <LoadingSpinner size="lg" text="Carregando apostas..." />
+        <div className="bg-neutral-900 min-h-screen">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div className="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, index) => (
+                <BetCardSkeleton key={index} />
+              ))}
+            </div>
+          </div>
         </div>
       ) : hasError ? (
         <div className="bg-neutral-900 min-h-screen flex items-center justify-center">
@@ -166,7 +169,6 @@ const HomePage: React.FC = () => {
       ) : (
         <BetsList
           groupedBets={filteredBets}
-          onVoteCreated={handleVoteCreated}
           onOpenCreateModal={() => setShowCreateModal(true)}
         />
       )}
@@ -284,7 +286,7 @@ const CategoryFilter: React.FC<CategoryFilterProps> = ({
   if (loading) {
     return (
       <div className="bg-gray-800 py-4">
-        <div className="container mx-auto px-4">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <LoadingSpinner size="sm" text="Carregando categorias..." />
         </div>
       </div>
@@ -294,7 +296,7 @@ const CategoryFilter: React.FC<CategoryFilterProps> = ({
   if (error) {
     return (
       <div className="bg-gray-800 py-4">
-        <div className="container mx-auto px-4">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <ErrorMessage error={error} />
         </div>
       </div>
@@ -378,13 +380,11 @@ interface BetsListProps {
     name: string;
     bets: Bet[];
   }>;
-  onVoteCreated: () => void;
   onOpenCreateModal: () => void;
 }
 
 const BetsList: React.FC<BetsListProps> = ({
   groupedBets,
-  onVoteCreated,
   onOpenCreateModal,
 }) => (
   <div className="bg-neutral-900 min-h-screen">
@@ -430,12 +430,12 @@ const BetsList: React.FC<BetsListProps> = ({
             {groupedBets.map((group) => (
               <div
                 key={group.id}
-                className="bg-gradient-to-br from-neutral-800 to-neutral-900 rounded-2xl p-6 lg:p-8 shadow-2xl border border-neutral-700"
+                className="bg-gradient-to-br from-neutral-800 to-neutral-900 rounded-2xl p-4 sm:p-6 lg:p-8 shadow-2xl border border-neutral-700 min-w-0"
               >
-                <div className="flex items-center space-x-4 mb-8">
-                  <div className="w-12 h-12 bg-gradient-to-br from-warning-400 to-orange-500 rounded-xl flex items-center justify-center">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4 mb-6 sm:mb-8 min-w-0">
+                  <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-warning-400 to-orange-500 rounded-xl flex items-center justify-center shrink-0">
                     <svg
-                      className="w-7 h-7 text-black"
+                      className="w-6 h-6 sm:w-7 sm:h-7 text-black"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -448,8 +448,8 @@ const BetsList: React.FC<BetsListProps> = ({
                       />
                     </svg>
                   </div>
-                  <div>
-                    <h2 className="text-3xl font-bold text-white">
+                  <div className="min-w-0">
+                    <h2 className="text-2xl sm:text-3xl font-bold text-white truncate">
                       {group.name}
                     </h2>
                     <p className="text-neutral-400 mt-1">
@@ -457,13 +457,9 @@ const BetsList: React.FC<BetsListProps> = ({
                     </p>
                   </div>
                 </div>
-                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                <div className="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                   {group.bets.map((bet) => (
-                    <BetCard
-                      key={bet.id}
-                      bet={bet}
-                      onVoteCreated={onVoteCreated}
-                    />
+                    <BetCard key={bet.id} bet={bet} />
                   ))}
                 </div>
               </div>

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import BetCardSkeleton from "../components/ui/BetCardSkeleton";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { Button } from "../components/ui/Button";
-import { Plus, Info } from "lucide-react";
+import { Plus, Info } from "@sarradahub/design-system";
 
 const HomePage: React.FC = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);

--- a/apps/web/src/types/bet.ts
+++ b/apps/web/src/types/bet.ts
@@ -1,31 +1,12 @@
-export type Bet = {
-  id: number;
-  title: string;
-  description?: string;
-  categoryId: number;
-  odds: {
-    id: number;
-    title: string;
-    value: number;
-    totalVotes: number;
-  }[];
-  totalVotes?: number;
-  // Backend may send ISO string; UI formats with date-fns
-  createdAt: string | Date;
-  // Align with UI usage in BetCard
-  status?: "open" | "closed" | "resolved";
-};
+export type {
+  BetListItem as Bet,
+  BetDetail,
+  BetStatus,
+  OddWithVotes as Odd,
+  OddDetail,
+  CreateBetDto,
+  UpdateBetDto,
+  CategoryRef,
+} from "@sarradabet/types";
 
-export type CreateBetDto = {
-  title: string;
-  description?: string;
-  categoryId: number; // Required to match backend validation
-  odds: Array<{
-    title: string;
-    value: number;
-  }>;
-};
-
-export type UpdateBetDto = Partial<CreateBetDto> & {
-  status?: "open" | "closed" | "resolved";
-};
+export type { CategoryRef as BetCategory } from "@sarradabet/types";

--- a/apps/web/src/types/category.ts
+++ b/apps/web/src/types/category.ts
@@ -1,15 +1,5 @@
-export type Category = {
-  id: number;
-  title: string;
-  createdAt?: string;
-  updatedAt?: string;
-  _count?: {
-    bet: number;
-  };
-};
-
-export type CreateCategoryDto = {
-  title: string;
-};
-
-export type UpdateCategoryDto = Partial<CreateCategoryDto>;
+export type {
+  Category,
+  CreateCategoryDto,
+  UpdateCategoryDto,
+} from "@sarradabet/types";

--- a/apps/web/src/types/odd.ts
+++ b/apps/web/src/types/odd.ts
@@ -1,6 +1,1 @@
-export type Odd = {
-  id: number;
-  title: string;
-  value: number;
-  totalVotes: number;
-};
+export type { OddWithVotes as Odd } from "@sarradabet/types";

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,14 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
           });
         },
       },
+      "/socket.io": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
 });

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,44 +2,32 @@
 
 ## Overview
 
-The SarradaBet API is a RESTful API built with Express.js and TypeScript, following clean architecture principles. It provides endpoints for managing betting markets, categories, and votes.
+The SarradaBet API is a RESTful API built with Express.js and TypeScript, with a **Socket.io** realtime layer for live odds and bet updates. Types are shared via `@sarradabet/types` in `packages/types`.
 
 ## Base Information
 
-- **Base URL**: `http://localhost:3001/api/v1`
-- **Protocol**: HTTP/HTTPS
+- **REST base URL**: `http://localhost:8000/api/v1`
+- **Socket.io URL**: `http://localhost:8000` (path: `/socket.io`)
+- **Protocol**: HTTP/HTTPS + WebSocket (via Socket.io)
 - **Content Type**: `application/json`
-- **Authentication**: API Key (Header: `X-API-Key`)
+- **Compression**: gzip for responses above ~1KB (when client sends `Accept-Encoding: gzip`)
 
 ## Authentication
 
-### API Key Authentication
+### Public endpoints
 
-Include your API key in the request headers:
+No authentication required:
 
-```http
-X-API-Key: your-api-key-here
-```
+- `GET/POST` `/api/v1/bets`, `/api/v1/categories`, `POST /api/v1/votes`
+- `GET /health`, `GET /ready`
 
-### Error Responses
+### Admin endpoints
 
-If authentication fails:
+Routes under `/api/v1/admin/*` require a JWT in the `Authorization: Bearer <token>` header (obtained via `POST /api/v1/admin/login`).
 
-```json
-{
-  "success": false,
-  "message": "Unauthorized access",
-  "errors": [
-    {
-      "field": "authentication",
-      "message": "Invalid or missing API key",
-      "code": "UNAUTHORIZED"
-    }
-  ],
-  "requestId": "req_123456789",
-  "timestamp": "2024-01-01T00:00:00.000Z"
-}
-```
+### API key (optional, not mounted)
+
+An `X-API-Key` middleware exists in code but is **not applied** to routes today. Do not rely on API key auth for public betting endpoints.
 
 ## Response Format
 
@@ -85,33 +73,47 @@ All error responses follow this format:
 
 ## Data Models
 
-### Bet
+Types are defined in [`packages/types`](../packages/types/src/index.ts). List and mutation responses use **slim DTOs**; detail endpoints return full **`BetDetail`**.
+
+### BetListItem (list, create, update, close)
+
+Used in `GET /bets`, `bet:created`, and `bet:updated` events.
 
 ```typescript
-interface Bet {
+interface BetListItem {
   id: number;
   title: string;
-  description: string | null;
+  description?: string | null;
   status: "open" | "closed" | "resolved";
-  categoryId: number | null;
-  createdAt: string; // ISO 8601 date
-  updatedAt: string; // ISO 8601 date
-  resolvedAt: string | null; // ISO 8601 date
-  odds: Odd[];
-  totalVotes?: number;
+  categoryId: number;
+  category?: { id: number; title: string };
+  totalVotes: number;
+  createdAt: string; // ISO 8601
+  odds: OddWithVotes[];
+}
+
+interface OddWithVotes {
+  id: number;
+  title: string;
+  value: number;
+  totalVotes: number;
 }
 ```
 
-### Odd
+### BetDetail (GET /bets/:id, resolve)
+
+Extends list shape with timestamps and full odd fields:
 
 ```typescript
-interface Odd {
-  id: number;
-  title: string;
-  value: number; // Decimal odds (e.g., 2.50)
-  totalVotes: number;
-  result: "pending" | "won" | "lost" | null;
-  betId: number;
+interface BetDetail extends BetListItem {
+  updatedAt: string;
+  resolvedAt?: string | null;
+  odds: OddDetail[];
+}
+
+interface OddDetail extends OddWithVotes {
+  result?: "pending" | "won" | "lost";
+  betId?: number;
 }
 ```
 
@@ -129,16 +131,55 @@ interface Category {
 }
 ```
 
-### Vote
+### Vote (create response)
 
 ```typescript
-interface Vote {
-  id: number;
-  oddId: number;
-  createdAt: string; // ISO 8601 date
-  odd?: Odd; // Included when fetching with relations
+interface VoteCreateResponse {
+  vote: {
+    id: number;
+    oddId: number;
+    createdAt: string;
+  };
+  betId: number;
+  odds: { id: number; totalVotes: number }[];
+  totalVotes: number;
 }
 ```
+
+## Realtime API (Socket.io)
+
+Connect to the same host as REST. Event names and payloads match [`packages/types/src/realtime.ts`](../packages/types/src/realtime.ts).
+
+| Field | Value |
+|-------|-------|
+| URL | `http://localhost:8000` (production: your API host) |
+| Path | `/socket.io` |
+| Transport | WebSocket with polling fallback |
+
+### Events
+
+| Event | Payload | Trigger |
+|-------|---------|---------|
+| `vote:created` | `{ betId, oddId, odds[{id,totalVotes}], totalVotes }` | `POST /votes` |
+| `bet:created` | `BetListItem` | `POST /bets` |
+| `bet:updated` | `BetListItem` | bet update, close, resolve |
+
+### Listener example (Node.js)
+
+```javascript
+import { io } from "socket.io-client";
+
+const socket = io("http://localhost:8000", { path: "/socket.io" });
+
+socket.on("vote:created", (payload) => {
+  console.log("vote:created", payload);
+});
+
+socket.on("bet:created", (bet) => console.log("bet:created", bet.id));
+socket.on("bet:updated", (bet) => console.log("bet:updated", bet.id));
+```
+
+Clients should prefer Socket.io push over polling `GET /bets/:id` after votes.
 
 ## Endpoints
 
@@ -197,23 +238,20 @@ GET /api/v1/bets?page=1&limit=10&status=open&sortBy=createdAt&sortOrder=desc
         "description": "Championship final match",
         "status": "open",
         "categoryId": 1,
+        "category": { "id": 1, "title": "Sports" },
         "createdAt": "2024-01-01T00:00:00.000Z",
-        "updatedAt": "2024-01-01T00:00:00.000Z",
-        "resolvedAt": null,
         "odds": [
           {
             "id": 1,
             "title": "Yes",
             "value": 2.5,
-            "totalVotes": 45,
-            "result": "pending"
+            "totalVotes": 45
           },
           {
             "id": 2,
             "title": "No",
             "value": 1.67,
-            "totalVotes": 67,
-            "result": "pending"
+            "totalVotes": 67
           }
         ],
         "totalVotes": 112
@@ -715,11 +753,19 @@ Create a new vote.
       "id": 1,
       "oddId": 1,
       "createdAt": "2024-01-01T00:00:00.000Z"
-    }
+    },
+    "betId": 1,
+    "odds": [
+      { "id": 1, "totalVotes": 46 },
+      { "id": 2, "totalVotes": 67 }
+    ],
+    "totalVotes": 113
   },
   "message": "Vote created successfully"
 }
 ```
+
+Also emits **`vote:created`** on Socket.io with the same aggregate counts.
 
 ## Error Codes
 
@@ -745,6 +791,22 @@ Create a new vote.
 - `FORBIDDEN` - Access denied
 - `RATE_LIMIT` - Too many requests
 - `DATABASE_ERROR` - Database operation failed
+
+## HTTP Caching and Compression
+
+### Category list cache headers
+
+`GET /api/v1/categories` responses include:
+
+```http
+Cache-Control: public, max-age=300, stale-while-revalidate=60
+```
+
+### Compression
+
+JSON responses larger than ~1KB may include `Content-Encoding: gzip` when the client accepts gzip.
+
+See [Performance Guide](./PERFORMANCE.md) for backend `node-cache` TTLs and Supabase pooling.
 
 ## Rate Limiting
 
@@ -785,21 +847,21 @@ Cross-Origin Resource Sharing is configured with:
 
 ### Complete Betting Flow
 
+0. **Optional — listen for realtime events** (see Realtime API section above).
+
 1. **Create a category:**
 
    ```bash
-   curl -X POST http://localhost:3001/api/v1/categories \
+   curl -X POST http://localhost:8000/api/v1/categories \
      -H "Content-Type: application/json" \
-     -H "X-API-Key: your-api-key" \
      -d '{"title": "Sports"}'
    ```
 
 2. **Create a bet:**
 
    ```bash
-   curl -X POST http://localhost:3001/api/v1/bets \
+   curl -X POST http://localhost:8000/api/v1/bets \
      -H "Content-Type: application/json" \
-     -H "X-API-Key: your-api-key" \
      -d '{
        "title": "Will Team A win?",
        "categoryId": 1,
@@ -813,24 +875,22 @@ Cross-Origin Resource Sharing is configured with:
 3. **Vote on an odd:**
 
    ```bash
-   curl -X POST http://localhost:3001/api/v1/votes \
+   curl -X POST http://localhost:8000/api/v1/votes \
      -H "Content-Type: application/json" \
-     -H "X-API-Key: your-api-key" \
      -d '{"oddId": 1}'
    ```
 
 4. **Close the bet:**
 
    ```bash
-   curl -X PATCH http://localhost:3001/api/v1/bets/1/close \
-     -H "X-API-Key: your-api-key"
+   curl -X PATCH http://localhost:8000/api/v1/bets/1/close
    ```
 
 5. **Resolve the bet:**
+
    ```bash
-   curl -X PATCH http://localhost:3001/api/v1/bets/1/resolve \
+   curl -X PATCH http://localhost:8000/api/v1/bets/1/resolve \
      -H "Content-Type: application/json" \
-     -H "X-API-Key: your-api-key" \
      -d '{"winningOddId": 1}'
    ```
 
@@ -846,8 +906,7 @@ import {
 } from "@sarradabet/api-client";
 
 const betService = new BetService({
-  baseURL: "http://localhost:3001/api/v1",
-  apiKey: "your-api-key",
+  baseURL: "http://localhost:8000/api/v1",
 });
 
 // Create a bet
@@ -882,7 +941,7 @@ class SarradaBetClient:
         )
         return response.json()
 
-client = SarradaBetClient('http://localhost:3001/api/v1', 'your-api-key')
+client = SarradaBetClient('http://localhost:8000/api/v1')
 ```
 
 ## Support

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SarradaBet follows **Clean Architecture** principles, ensuring separation of concerns, testability, and maintainability. The system is built as a monorepo with separate frontend and backend applications.
+SarradaBet follows **Clean Architecture** principles with a **Socket.io realtime layer** for push updates on votes and bet mutations. Shared contracts live in `@sarradabet/types` (`packages/types`).
 
 ## Architecture Principles
 
@@ -48,27 +48,76 @@ apps/api/src/
 │   ├── validation/                # Validation schemas
 │   │   ├── ValidationSchemas.ts   # Zod validation schemas
 │   │   └── SanitizationSchemas.ts # Input sanitization
+│   ├── cache/                     # In-memory cache (node-cache)
+│   │   └── CacheService.ts
 │   └── middleware/                # Core middleware
 │       ├── ErrorHandler.ts        # Global error handling
 │       ├── ValidationMiddleware.ts # Request validation
-│       └── SecurityMiddleware.ts  # Security middleware
+│       ├── SecurityMiddleware.ts  # Security middleware
+│       └── cacheHeaders.ts        # Cache-Control for GET routes
+├── realtime/                      # Socket.io layer
+│   ├── socket.ts                  # IO server on HTTP server
+│   └── emitter.ts                 # Typed event broadcast
 ├── modules/                       # Feature modules
-│   ├── bet/                      # Bet management
-│   │   ├── repositories/         # Data access layer
-│   │   ├── services/            # Business logic layer
-│   │   ├── controllers/         # Presentation layer
-│   │   ├── routes/              # API routes
-│   │   └── __tests__/           # Tests
-│   ├── category/                # Category management
-│   └── vote/                    # Voting system
-├── config/                       # Configuration
-│   └── env.ts                   # Environment configuration
-├── routes/                       # Main routing
-│   └── index.ts                 # Route aggregation
-├── utils/                        # Utilities
-│   └── logger.ts                # Logging utility
-└── app.ts                       # Application setup
+│   ├── bet/
+│   │   ├── repositories/
+│   │   ├── services/
+│   │   ├── controllers/
+│   │   ├── mappers/               # Slim BetListItem / BetDetail DTOs
+│   │   └── __tests__/
+│   ├── category/
+│   └── admin/
+├── config/                        # env.ts, db.ts, consul
+├── routes/                        # Route aggregation
+├── utils/
+├── app.ts                         # Express + REST + compression
+└── server.ts                      # HTTP server + Socket.io bootstrap
 ```
+
+## Realtime Architecture
+
+Vote and bet mutations emit Socket.io events after the database transaction succeeds. Clients subscribe instead of polling REST.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant REST as Express_REST
+  participant Svc as VoteService_BetService
+  participant IO as Socket_io
+  participant DB as Postgres
+
+  Client->>REST: POST /api/v1/votes
+  REST->>Svc: createVote
+  Svc->>DB: transaction + aggregate counts
+  Svc->>IO: emit vote:created
+  IO->>Client: push payload
+  Note over Client: RealtimeProvider patches query cache; BetCard updates odds
+```
+
+| Event | Emitter | Payload |
+|-------|---------|---------|
+| `vote:created` | `vote.service.ts` | `{ betId, oddId, odds[], totalVotes }` |
+| `bet:created` | `BetService.create` | `BetListItem` |
+| `bet:updated` | `BetService` update/close/resolve | `BetListItem` |
+
+Event contracts: [`packages/types/src/realtime.ts`](../packages/types/src/realtime.ts). API reference: [API.md](./API.md#realtime-api-socketio).
+
+**Scaling note:** broadcasts are in-process. Multiple API instances need `@socket.io/redis-adapter` — see [PERFORMANCE.md](./PERFORMANCE.md).
+
+## Caching and Performance Layers
+
+| Layer | Implementation | Notes |
+|-------|----------------|-------|
+| Backend memory | `CacheService` (node-cache) | Categories 5m, resolved bets 2m, bet detail 30s |
+| HTTP headers | `cacheHeaders` middleware | `GET /api/v1/categories` |
+| Response size | `bet.mapper.ts` | Slim list DTOs vs full detail |
+| Wire format | `compression` middleware | gzip above ~1KB |
+| Frontend | `useQuery` + `queryCache` | Stale-while-revalidate; `RealtimeProvider` patches cache |
+| Frontend UI | `OddsList` optimistic vote | Rollback on error; socket reconciles counts |
+
+## Shared Types
+
+The `@sarradabet/types` package exports `BetListItem`, `BetDetail`, `Category`, and `RealtimeEvents`. Both `apps/api` and `apps/web` depend on it.
 
 ### Layer Responsibilities
 
@@ -251,36 +300,31 @@ apps/web/src/
 │   │   └── BaseService.ts       # HTTP service base
 │   └── hooks/                   # Core hooks
 │       ├── useApi.ts            # Generic API hook
-│       ├── useQuery.ts          # Query hook
-│       ├── useMutation.ts       # Mutation hook
-│       └── index.ts             # Hook exports
+│       ├── useQuery.ts          # Query + cache + SWR
+│       ├── useMutation.ts       # Mutations + onMutate/onRollback
+│       ├── useSocket.ts         # Socket.io client
+│       └── useQueryCache.ts     # In-memory query cache
+├── context/
+│   └── RealtimeProvider.tsx     # Socket listeners → cache patches
 ├── services/                    # API services
 │   ├── BetService.ts           # Bet API service
 │   ├── CategoryService.ts      # Category API service
 │   └── VoteService.ts          # Vote API service
 ├── hooks/                       # Domain-specific hooks
-│   ├── useBets.ts              # Bet-related hooks
-│   ├── useCategories.ts        # Category-related hooks
-│   ├── useVotes.ts             # Vote-related hooks
-│   └── index.ts                # Hook exports
-├── components/                  # React components
-│   ├── ui/                     # Reusable UI components
-│   │   ├── Button.tsx          # Button component
-│   │   ├── Modal.tsx           # Modal component
-│   │   ├── LoadingSpinner.tsx  # Loading spinner
-│   │   └── ErrorMessage.tsx    # Error display
-│   ├── CreateBetModal.tsx      # Bet creation modal
-│   ├── BetCard.tsx             # Bet display card
-│   └── OddsList.tsx            # Odds display
-├── pages/                       # Page components
-│   └── HomePage.tsx            # Main page
-├── types/                       # TypeScript types
-│   ├── bet.ts                  # Bet types
-│   ├── category.ts             # Category types
-│   └── vote.ts                 # Vote types
-├── utils/                       # Utility functions
-│   └── cn.ts                   # Class name utility
-└── App.tsx                     # Main app component
+│   ├── useBets.ts              # staleTime 2m
+│   ├── useCategories.ts        # staleTime 5m
+│   └── useVotes.ts
+├── components/
+│   ├── ui/                     # Button, Modal, BetCardSkeleton, etc.
+│   ├── CreateBetModal.tsx
+│   ├── BetCard.tsx             # Socket vote updates + category from list
+│   └── OddsList.tsx            # Optimistic vote + rollback
+├── pages/
+│   ├── HomePage.tsx
+│   ├── AdminLogin.tsx          # lazy-loaded
+│   └── AdminDashboard.tsx      # lazy-loaded
+├── types/                       # Re-exports from @sarradabet/types
+└── App.tsx                     # Router + RealtimeProvider
 ```
 
 ### Frontend Patterns
@@ -348,35 +392,40 @@ export const useQuery = <T>(
   // Caching and stale time logic
 };
 
-// useMutation - Mutations with optimistic updates
-export const useMutation = <TData, TVariables>(
-  service: (variables: TVariables) => Promise<ApiResponse<TData>>,
-  options?: MutationOptions,
-) => {
-  // Optimistic updates and error handling
-};
+// useMutation - Mutations with optional optimistic updates
+export function useMutation<TData, TVariables, TContext = unknown>(
+  mutationFn: (variables: TVariables) => Promise<ApiResponse<TData>>,
+  options?: {
+    onMutate?: (variables: TVariables) => TContext | void;
+    onRollback?: (context: TContext, error: ApiError, variables: TVariables) => void;
+    onSuccess?: (data: TData, variables: TVariables) => void;
+  },
+) {
+  // Runs onMutate before request; onRollback on failure
+}
 ```
 
-**Domain Hooks** combine core hooks with domain logic:
+**Domain Hooks** use custom cache keys and stale times:
 
 ```typescript
 export const useBets = (params?: BetQueryParams) => {
   return useQuery(
     `bets-${JSON.stringify(params)}`,
-    () => betService.getBets(params),
-    { staleTime: 30000 }, // 30 seconds
+    () => betService.getBetsWithPagination(params),
+    { staleTime: 2 * 60 * 1000, refetchOnMount: false },
   );
 };
 
-export const useCreateBet = () => {
-  return useMutation(betService.createBet, {
-    onSuccess: () => {
-      // Invalidate and refetch bets
-      queryClient.invalidateQueries(["bets"]);
-    },
-  });
+export const useCategories = () => {
+  return useQuery(
+    `categories-...`,
+    () => categoryService.getCategoriesWithPagination(),
+    { staleTime: 5 * 60 * 1000 },
+  );
 };
 ```
+
+**RealtimeProvider** listens for Socket.io events and patches `queryCache` keys prefixed with `bets-`. **OddsList** applies optimistic vote counts; **BetCard** reconciles via `vote:created` events.
 
 #### 3. Component Composition
 
@@ -663,20 +712,22 @@ __tests__/
 
 ```
 Developer Machine
-├── Node.js (Backend)
-├── React Dev Server (Frontend)
-└── Docker (PostgreSQL)
+├── API (Express + Socket.io) — localhost:8000
+├── Vite dev server — localhost:3002
+└── Docker db (Postgres) — localhost:5433
 ```
 
 ### Production Environment
 
 ```
 Production Server
-├── Nginx (Reverse Proxy)
-├── Node.js (Backend API)
-├── React (Static Files)
-└── PostgreSQL (Database)
+├── Nginx (Reverse Proxy + WebSocket upgrade for /socket.io)
+├── Node.js (Backend API + Socket.io)
+├── React static files (Vite build)
+└── PostgreSQL (Supabase or self-hosted)
 ```
+
+Alternative cloud hosting: see [DEPLOYMENT.md](./DEPLOYMENT.md#alternative-render--vercel).
 
 ## Monitoring and Observability
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This guide covers deploying the SarradaBet application to production environments. The application consists of a Node.js backend API and a React frontend, with PostgreSQL as the database.
+This guide covers deploying the SarradaBet application to production. The stack includes an Express API with **Socket.io**, a React frontend, and PostgreSQL. For local development setup, see the [Main README](../README.md).
+
+**Default API port:** `8000` (configurable via `PORT`).
 
 ## Deployment Options
 
@@ -54,19 +56,19 @@ services:
     container_name: sarradabet-api
     environment:
       NODE_ENV: production
-      PORT: 3001
+      PORT: 8000
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/sarradabet_prod
+      DIRECT_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/sarradabet_prod
       CORS_ORIGINS: ${CORS_ORIGINS}
-      API_KEY: ${API_KEY}
       JWT_SECRET: ${JWT_SECRET}
     ports:
-      - "3001:3001"
+      - "8000:8000"
     depends_on:
       postgres:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -150,7 +152,7 @@ COPY --from=builder --chown=nodejs:nodejs /app/prisma ./prisma
 USER nodejs
 
 # Expose port
-EXPOSE 3001
+EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
@@ -205,7 +207,7 @@ Create `nginx.conf`:
 
 ```nginx
 upstream api {
-    server api:3001;
+    server api:8000;
 }
 
 upstream web {
@@ -253,6 +255,18 @@ server {
         limit_req zone=api burst=20 nodelay;
     }
 
+    # Socket.io (realtime)
+    location /socket.io/ {
+        proxy_pass http://api;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Health Check
     location /health {
         proxy_pass http://api;
@@ -287,19 +301,19 @@ http {
 Create `.env.prod`:
 
 ```env
-# Database
-POSTGRES_USER=sarradabet_user
-POSTGRES_PASSWORD=your_secure_password_here
+# Database (Prisma)
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/sarradabet_prod
+DIRECT_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/sarradabet_prod
 
 # API
-API_KEY=your_production_api_key_here
 JWT_SECRET=your_jwt_secret_key_here
+PORT=8000
 
-# CORS
+# CORS (must include your frontend origin for Socket.io)
 CORS_ORIGINS=https://your-domain.com,https://www.your-domain.com
 
-# Frontend
-VITE_API_URL=https://your-domain.com/api/v1
+# Frontend build — API base URL only (no /api/v1 suffix)
+VITE_API_URL=https://api.your-domain.com
 ```
 
 ### Deployment Commands
@@ -407,7 +421,7 @@ module.exports = {
       cwd: "/var/www/sarradabet",
       env: {
         NODE_ENV: "production",
-        PORT: 3001,
+        PORT: 8000,
       },
       instances: "max",
       exec_mode: "cluster",
@@ -464,7 +478,7 @@ server {
 
     # API routes
     location /api/ {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://localhost:8000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -477,7 +491,7 @@ server {
 
     # Health check
     location /health {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://localhost:8000;
         access_log off;
     }
 
@@ -605,7 +619,7 @@ const http = require("http");
 
 const options = {
   hostname: "localhost",
-  port: process.env.PORT || 3001,
+  port: process.env.PORT || 8000,
   path: "/health",
   method: "GET",
 };
@@ -816,6 +830,33 @@ docker-compose down
 docker-compose up -d --scale api=0
 docker-compose up -d
 ```
+
+## Alternative: Render + Vercel
+
+For managed hosting without self-managed Docker/nginx:
+
+### API (Render)
+
+- **Root directory:** `apps/api`
+- **Build:** `npm install && npm run build && npm run prisma:generate`
+- **Start:** `npm run start`
+- **Environment:**
+  - `DATABASE_URL` — Supabase pooler (`6543?pgbouncer=true`)
+  - `DIRECT_URL` — Supabase direct (`5432`, migrations)
+  - `CORS_ORIGINS` — your Vercel frontend URL
+  - `JWT_SECRET`, `PORT` (Render sets `PORT` automatically)
+- **WebSockets:** supported on a single Render web service; see [PERFORMANCE.md](./PERFORMANCE.md) for multi-instance Redis adapter.
+
+### Web (Vercel)
+
+- **Root directory:** `apps/web`
+- **Build:** `npm run build`
+- **Environment:** `VITE_API_URL=https://your-api.onrender.com` (no `/api/v1` suffix)
+- **Config:** [`apps/web/vercel.json`](../apps/web/vercel.json) — SPA rewrites + immutable asset cache
+
+### Migrations
+
+Run `npm run prisma:migrate:deploy` in CI or a one-off Render shell with `DATABASE_URL` and `DIRECT_URL` set (see [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml)).
 
 ## Security Considerations
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -849,10 +849,22 @@ For managed hosting without self-managed Docker/nginx:
 
 ### Web (Vercel)
 
+The web app depends on `@sarradahub/design-system` from the sibling [`SarradaHub/platform`](https://github.com/SarradaHub/platform) repo. Vercel must clone that repo before install/build (handled by [`scripts/clone-platform.sh`](../scripts/clone-platform.sh)).
+
+**Option A — monorepo root (recommended, matches Turborepo):**
+
+- **Root directory:** `.` (repository root)
+- **Install / build / output:** defined in root [`vercel.json`](../vercel.json) — clones platform, builds design-system, then `turbo run build --filter=web`
+- **Output directory:** `apps/web/dist`
+
+**Option B — web app only:**
+
 - **Root directory:** `apps/web`
-- **Build:** `npm run build`
-- **Environment:** `VITE_API_URL=https://your-api.onrender.com` (no `/api/v1` suffix)
-- **Config:** [`apps/web/vercel.json`](../apps/web/vercel.json) — SPA rewrites + immutable asset cache
+- **Install / build / output:** defined in [`apps/web/vercel.json`](../apps/web/vercel.json)
+
+**Environment:** `VITE_API_URL=https://your-api.onrender.com` (no `/api/v1` suffix)
+
+If the Vercel project dashboard overrides **Install Command** or **Build Command**, remove those overrides so `vercel.json` settings apply (or set them to the same values). A bare `turbo run build` without cloning platform will fail with `Cannot find module '@sarradahub/design-system'`.
 
 ### Migrations
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@ This guide will help you set up your development environment and understand how 
 
 ### Required Software
 
-- **Node.js** 18.0.0 or higher
+- **Node.js** 20.0.0 or higher
 - **npm** 9.0.0 or higher
 - **Docker Desktop** (for database)
 - **Git** (for version control)
@@ -46,48 +46,49 @@ npm install
 
 ### 3. Environment Setup
 
-#### Backend Environment
+Copy the committed example files and adjust secrets if needed:
 
-Create `apps/api/.env`:
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+#### Backend (`apps/api/.env`)
+
+Key variables (see [`apps/api/.env.example`](../apps/api/.env.example) for the full list):
 
 ```env
-# Application
 NODE_ENV=development
-PORT=3001
-
-# Database
-DATABASE_URL="postgresql://postgres:password@localhost:5432/sarradabet_dev"
-
-# CORS
-CORS_ORIGINS="http://localhost:3000,http://localhost:3001"
-
-# API
-API_KEY="dev-api-key-12345"
-
-# JWT (for future auth)
-JWT_SECRET="dev-jwt-secret-key"
+PORT=8000
+CORS_ORIGINS=http://localhost:3002,http://localhost:5173
+DATABASE_URL=postgresql://appuser:sarradabet1234@localhost:5433/sarradabet
+DIRECT_URL=postgresql://appuser:sarradabet1234@localhost:5433/sarradabet
+JWT_SECRET=dev-jwt-secret-change-me
 ```
 
-#### Frontend Environment
+- **`DIRECT_URL`** is required by Prisma (same as `DATABASE_URL` for local Docker; use Supabase direct port `5432` in production).
+- **`CORS_ORIGINS`** must include the web dev URL or Socket.io connections will fail.
 
-Create `apps/web/.env`:
+#### Frontend (`apps/web/.env`)
 
 ```env
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=http://localhost:8000
 ```
+
+Use the API **base URL only** — do not append `/api/v1` (the client adds it).
 
 ### 4. Database Setup
 
 ```bash
-# Start PostgreSQL with Docker
-docker-compose up -d postgres
+# Start PostgreSQL (service name is "db", not "postgres")
+docker compose up -d db
 
 # Run migrations
 cd apps/api
 npm run prisma:migrate:dev
 
 # Seed database (optional)
-npm run prisma:seed
+npm run db:seed:simple
 ```
 
 ### 5. Start Development Servers
@@ -99,9 +100,14 @@ npm run dev
 
 This will start:
 
-- Backend API: `http://localhost:3001`
-- Frontend: `http://localhost:3000`
-- Database: `localhost:5432`
+| Service | URL |
+|---------|-----|
+| Backend API | http://localhost:8000 |
+| Frontend | http://localhost:3002 |
+| Socket.io | http://localhost:8000/socket.io |
+| Database | localhost:5433 |
+
+Vite proxies `/api` and `/socket.io` to the API in dev when using relative URLs. With `VITE_API_URL` set, the client connects directly to the API.
 
 ## Project Structure
 
@@ -113,7 +119,7 @@ sarradabet/
 │   ├── api/                 # Backend API
 │   └── web/                 # Frontend React app
 ├── packages/
-│   └── types/               # Shared TypeScript types
+│   └── types/               # @sarradabet/types — shared contracts
 ├── docs/                    # Documentation
 ├── docker-compose.yml       # Docker services
 ├── package.json             # Root package.json
@@ -125,12 +131,16 @@ sarradabet/
 ```
 apps/api/
 ├── src/
-│   ├── core/               # Core architecture
-│   ├── modules/            # Feature modules
-│   ├── config/             # Configuration
-│   ├── routes/             # API routes
-│   ├── utils/              # Utilities
-│   └── app.ts              # Application setup
+│   ├── core/               # Base classes, cache, middleware
+│   │   ├── cache/          # node-cache wrapper
+│   │   └── middleware/     # Validation, security, cache headers
+│   ├── realtime/           # Socket.io server + event emitter
+│   ├── modules/            # Feature modules (bet, category, admin)
+│   ├── config/             # env, db, consul
+│   ├── routes/             # Route aggregation
+│   ├── utils/              # Logger, auth helpers
+│   ├── app.ts              # Express middleware + REST routes
+│   └── server.ts           # HTTP server + Socket.io bootstrap
 ├── prisma/
 │   ├── schema.prisma       # Database schema
 │   └── migrations/         # Database migrations
@@ -144,17 +154,19 @@ apps/api/
 ```
 apps/web/
 ├── src/
-│   ├── core/               # Core architecture
-│   ├── services/           # API services
-│   ├── hooks/              # Custom hooks
-│   ├── components/         # React components
-│   ├── pages/              # Page components
-│   ├── types/              # TypeScript types
+│   ├── core/               # Hooks (useQuery, useMutation, useSocket)
+│   ├── context/            # RealtimeProvider (Socket.io cache patches)
+│   ├── services/           # API services (Axios)
+│   ├── hooks/              # Domain hooks (useBets, useCategories)
+│   ├── components/         # React components + ui/ skeletons
+│   ├── pages/              # HomePage, admin (lazy-loaded)
+│   ├── types/              # Re-exports from @sarradabet/types
 │   └── utils/              # Utilities
 ├── public/                 # Static assets
+├── vercel.json             # SPA rewrites + asset cache headers
 ├── __tests__/              # Tests
 ├── package.json
-└── vite.config.ts
+└── vite.config.ts          # Dev proxy for /api and /socket.io
 ```
 
 ## Development Workflow
@@ -383,14 +395,15 @@ export const useYourFeatures = (params?: YourFeatureQueryParams) => {
   return useQuery(
     `your-features-${JSON.stringify(params)}`,
     () => yourFeatureService.getYourFeatures(params),
-    { staleTime: 30000 },
+    { staleTime: 5 * 60 * 1000 }, // 5 minutes
   );
 };
 
 export const useCreateYourFeature = () => {
   return useMutation(yourFeatureService.createYourFeature, {
     onSuccess: () => {
-      queryClient.invalidateQueries(["your-features"]);
+      // Refetch or rely on RealtimeProvider if you emit socket events
+      // queryCache is updated via RealtimeProvider for bet/vote flows
     },
   });
 };
@@ -783,11 +796,12 @@ refactor(services): extract common validation logic
 **Database Debugging:**
 
 ```bash
-# Connect to database
-docker exec -it sarradabet-postgres psql -U postgres -d sarradabet_dev
+# Connect to local database (docker compose service: db)
+docker compose exec db psql -U appuser -d sarradabet
 
-# View logs
-docker logs sarradabet-postgres
+# View database logs
+docker compose logs db
+```
 ```
 
 ### Frontend Debugging
@@ -799,43 +813,29 @@ docker logs sarradabet-postgres
 
 **Network Debugging:**
 
-- Use browser DevTools Network tab
-- Check API request/response details
-- Monitor WebSocket connections
+- Use browser DevTools Network tab for REST calls
+- Check the **WS** filter for the `socket.io` connection
+- After voting, expect only `POST /api/v1/votes` — no follow-up `GET /api/v1/bets/:id`
+- Monitor Socket.io events: `vote:created`, `bet:created`, `bet:updated`
+
+## Validating Changes (Blackbox)
+
+Quick checks without reading internal code. Full checklist: [Performance Guide](./PERFORMANCE.md#blackbox-validation-checklist).
+
+1. **Two-browser realtime** — open http://localhost:3002 in two windows; vote in one; counts update in both without refresh.
+2. **DevTools** — confirm WebSocket to `/socket.io` and no post-vote bet refetch.
+3. **REST shape** — `curl http://localhost:8000/api/v1/bets?limit=1` returns slim odds (no `createdAt` on list items).
+4. **Cache headers** — `curl -D - http://localhost:8000/api/v1/categories -o /dev/null | grep -i cache-control`
+5. **Regression** — `npm run test:api` and `npm run test:web`
 
 ## Performance Optimization
 
-### Backend Optimization
+See [Performance Guide](./PERFORMANCE.md) for caching TTLs, Supabase pooling, Socket.io scaling, and the blackbox checklist.
 
-**Database:**
+Implemented in this codebase:
 
-- Add proper indexes
-- Optimize queries
-- Use connection pooling
-- Implement caching
-
-**API:**
-
-- Implement rate limiting
-- Use compression
-- Optimize response sizes
-- Cache frequently accessed data
-
-### Frontend Optimization
-
-**React:**
-
-- Use React.memo for expensive components
-- Implement code splitting
-- Optimize re-renders
-- Use proper key props
-
-**Bundle:**
-
-- Analyze bundle size
-- Remove unused code
-- Optimize images
-- Use CDN for static assets
+- **Backend:** `node-cache`, gzip compression, slim bet list DTOs, DB indexes on `categoryId` and `(status, created_at)`
+- **Frontend:** Socket.io push (no polling), optimistic votes, lazy admin routes, skeleton loaders, query cache with stale-while-revalidate
 
 ## Common Issues and Solutions
 
@@ -845,14 +845,14 @@ docker logs sarradabet-postgres
 
 ```bash
 # Check if PostgreSQL is running
-docker ps | grep postgres
+docker compose ps db
 
 # Restart database
-docker-compose restart postgres
+docker compose restart db
 
 # Reset database
-docker-compose down -v
-docker-compose up -d postgres
+docker compose down -v
+docker compose up -d db
 ```
 
 **TypeScript Compilation Errors:**

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,110 @@
+# Performance Guide
+
+Cross-links: [Architecture](./ARCHITECTURE.md#caching-and-performance-layers) | [API caching headers](./API.md#http-caching-and-compression) | [Deployment pooling](./DEPLOYMENT.md) | [Developer blackbox checks](./DEVELOPER_GUIDE.md#validating-changes-blackbox)
+
+## Database indexes
+
+Migration [`20250614000000_add_bet_performance_indexes`](../apps/api/prisma/migrations/20250614000000_add_bet_performance_indexes/migration.sql) adds:
+
+- `bets(categoryId)` — category filter / `findByCategory`
+- `bets(status, created_at DESC)` — status list queries
+
+## Database query audit (Supabase)
+
+Run in the Supabase SQL Editor:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+SELECT
+  query,
+  calls,
+  mean_exec_time,
+  total_exec_time
+FROM pg_stat_statements
+ORDER BY mean_exec_time DESC
+LIMIT 20;
+```
+
+Use **Database → Index Advisor** in the Supabase dashboard on the slowest queries (typically bet list with odds vote counts).
+
+## Connection pooling
+
+Use Supabase transaction pooler for runtime connections:
+
+- `DATABASE_URL` — pooler host, port `6543`, append `?pgbouncer=true`
+- `DIRECT_URL` — direct host, port `5432` (migrations only)
+
+Example:
+
+```env
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true
+DIRECT_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
+```
+
+## Realtime (Socket.io)
+
+The API pushes events on `/socket.io`:
+
+| Event | Trigger |
+|-------|---------|
+| `vote:created` | New vote |
+| `bet:created` | New bet |
+| `bet:updated` | Bet update, close, resolve |
+
+Payload shapes: [`packages/types/src/realtime.ts`](../packages/types/src/realtime.ts). REST + listener examples: [API.md](./API.md#realtime-api-socketio).
+
+## Caching
+
+| Layer | What | TTL |
+|-------|------|-----|
+| Backend `node-cache` | Categories list | 5 min |
+| Backend `node-cache` | Resolved bets | 2 min |
+| Backend `node-cache` | Single bet detail | 30 s |
+| HTTP `Cache-Control` | `GET /api/v1/categories` | 5 min + SWR 60 s |
+| Frontend query cache | Categories | 5 min stale |
+
+## Horizontal scaling note
+
+Socket.io broadcasts are in-memory. If Render runs multiple API instances, add `@socket.io/redis-adapter` for cross-instance fan-out.
+
+## Blackbox validation checklist
+
+Run against a live stack (`npm run dev` locally or deployed URLs).
+
+### REST
+
+```bash
+# Health
+curl -s http://localhost:8000/health | jq .
+
+# Slim list DTO (odds without result/createdAt on list)
+curl -s 'http://localhost:8000/api/v1/bets?limit=1' | jq '.data.data[0].odds[0]'
+
+# Category cache headers
+curl -s -D - http://localhost:8000/api/v1/categories -o /dev/null | grep -i cache-control
+
+# Gzip
+curl -s -H 'Accept-Encoding: gzip' -D - \
+  'http://localhost:8000/api/v1/bets?limit=50' -o /dev/null | grep -i content-encoding
+```
+
+### Socket.io + vote
+
+1. Start a Socket.io listener (see [API.md](./API.md#realtime-api-socketio)).
+2. `curl -X POST http://localhost:8000/api/v1/votes -H 'Content-Type: application/json' -d '{"oddId": 1}'`
+3. Expect `vote:created` on the listener with updated `totalVotes`.
+
+### Browser (two clients)
+
+1. Open http://localhost:3002 in two windows.
+2. Vote in window A.
+3. Window B updates counts without refresh.
+4. DevTools: only `POST /votes` after click — no `GET /bets/:id`.
+
+### Regression
+
+```bash
+npm run test:api
+npm run test:web
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,26 +11,27 @@ Welcome to the comprehensive documentation for the SarradaBet betting platform. 
 
 ### Architecture & Design
 
-- **[Architecture Documentation](./ARCHITECTURE.md)** - Clean architecture principles, system design, and patterns
-- **[API Documentation](./API.md)** - Complete API reference with examples and schemas
+- **[Architecture Documentation](./ARCHITECTURE.md)** - Clean architecture, realtime data flow, and patterns
+- **[API Documentation](./API.md)** - REST reference, Socket.io events, and schemas
 
 ### Deployment & Operations
 
-- **[Deployment Guide](./DEPLOYMENT.md)** - Production deployment strategies and server management
+- **[Deployment Guide](./DEPLOYMENT.md)** - Production deployment (Docker/nginx primary)
+- **[Performance Guide](./PERFORMANCE.md)** - Caching, pooling, realtime scaling, blackbox validation
 
 ## 🚀 Quick Navigation
 
 ### For Developers
 
-1. Start with the [Developer Guide](./DEVELOPER_GUIDE.md) for setup instructions
-2. Review the [Architecture Documentation](./ARCHITECTURE.md) to understand the system design
-3. Use the [API Documentation](./API.md) for backend integration
+1. Start with the [Main README](../README.md) or [Developer Guide](./DEVELOPER_GUIDE.md) for setup
+2. Review [Architecture Documentation](./ARCHITECTURE.md) for realtime and caching design
+3. Use [API Documentation](./API.md) for REST + Socket.io integration
 
 ### For DevOps/System Administrators
 
 1. Follow the [Deployment Guide](./DEPLOYMENT.md) for production setup
-2. Review security considerations and monitoring setup
-3. Implement backup and maintenance procedures
+2. Review [Performance Guide](./PERFORMANCE.md) for Supabase pooling and scaling notes
+3. Implement backup and monitoring procedures
 
 ### For Product Managers/Business Users
 
@@ -44,187 +45,110 @@ Welcome to the comprehensive documentation for the SarradaBet betting platform. 
 docs/
 ├── README.md              # This index file
 ├── ARCHITECTURE.md        # System architecture and design patterns
-├── API.md                 # Complete API documentation
+├── API.md                 # REST + Socket.io API documentation
 ├── DEVELOPER_GUIDE.md     # Development setup and workflow
-└── DEPLOYMENT.md          # Production deployment guide
+├── DEPLOYMENT.md          # Production deployment guide
+└── PERFORMANCE.md         # Performance, caching, and validation
 ```
 
 ## 🎯 Key Features Covered
 
 ### Backend Architecture
 
-- **Clean Architecture** implementation with separation of concerns
-- **Repository Pattern** for data access layer
-- **Service Layer** for business logic
-- **Controller Layer** for request handling
-- **Validation System** with Zod schemas
-- **Error Handling** with custom error classes
-- **Security Middleware** with rate limiting and sanitization
+- **Clean Architecture** with separation of concerns
+- **Socket.io** realtime layer (`realtime/` — push on vote and bet mutations)
+- **Repository / Service / Controller** layers with Prisma ORM
+- **In-memory cache** (`node-cache`) for categories and resolved bets
+- **Response compression** and slim list DTOs via bet mappers
+- **Validation** with Zod; **security** middleware (Helmet, rate limiting, CORS)
 
 ### Frontend Architecture
 
-- **Modern React** patterns with hooks and functional components
-- **Custom Hooks** for state management and API integration
-- **Service Layer** for API communication
-- **Component Composition** with reusable UI components
-- **TypeScript** integration for type safety
+- **React 19** with custom hooks (`useQuery`, `useMutation`, `useSocket`)
+- **`RealtimeProvider`** — patches query cache on Socket.io events
+- **Optimistic voting** in `OddsList` with rollback on error
+- **Lazy-loaded admin routes** and skeleton loaders
+- **Shared types** via `@sarradabet/types`
 
 ### API Features
 
-- **RESTful API** design with proper HTTP status codes
-- **Input Validation** and sanitization
-- **Rate Limiting** and security measures
-- **Comprehensive Error Handling** with detailed error responses
-- **Pagination** and filtering support
-- **Health Checks** for monitoring
+- **RESTful API** at `/api/v1` plus **Socket.io** at `/socket.io`
+- **Public endpoints** for bets, categories, votes; **JWT** for admin routes
+- Pagination, filtering, health checks
+- **HTTP cache headers** on category list responses
 
 ### Testing
 
-- **Unit Tests** for business logic
-- **Integration Tests** for API endpoints
-- **Component Tests** for React components
-- **Hook Tests** for custom hooks
-- **Test Coverage** reporting
+- Unit tests for business logic and hooks
+- Integration tests for REST bet routes
+- Blackbox validation checklist in [Performance Guide](./PERFORMANCE.md)
 
 ### Security
 
-- **Input Validation** and sanitization
-- **Rate Limiting** to prevent abuse
-- **Security Headers** for protection
-- **CORS Configuration** for cross-origin requests
-- **API Key Authentication** (ready for JWT upgrade)
+- Input validation and sanitization
+- Rate limiting and security headers
+- CORS configuration (must include frontend origin for Socket.io)
+- JWT admin authentication
 
 ### Deployment
 
-- **Docker** containerization
-- **Nginx** reverse proxy configuration
-- **SSL/TLS** setup with Let's Encrypt
-- **Database** backup and maintenance
-- **Monitoring** and health checks
-- **CI/CD** ready configuration
+- **Docker / nginx / PM2** (primary path in Deployment Guide)
+- **Render + Vercel** addendum for cloud hosting
+- Database migrations with `DATABASE_URL` + `DIRECT_URL`
 
 ## 🔧 Technology Stack
 
 ### Backend
 
-- **Node.js** 18+ with Express.js
-- **TypeScript** for type safety
-- **PostgreSQL** with Prisma ORM
-- **Zod** for validation
-- **Jest** for testing
-- **Winston** for logging
+- **Node.js** ≥20, **Express.js**, **Socket.io**
+- **TypeScript**, **PostgreSQL**, **Prisma ORM**
+- **node-cache**, **compression**, **Zod**, **Jest**, **Winston**
 
 ### Frontend
 
-- **React** 19 with TypeScript
-- **Vite** for build tooling
-- **Tailwind CSS** for styling
-- **Vitest** and **React Testing Library** for testing
-- **Custom Hooks** for state management
+- **React** 19, **Vite**, **Tailwind CSS**
+- **socket.io-client**, custom query/mutation hooks
+- **Vitest**, **React Testing Library**
+
+### Shared
+
+- **`@sarradabet/types`** — `BetListItem`, `BetDetail`, `RealtimeEvents`
 
 ### DevOps
 
-- **Docker** for containerization
-- **Docker Compose** for orchestration
-- **Nginx** for reverse proxy
-- **PM2** for process management
-- **Git** for version control
-
-## 📊 Project Statistics
-
-- **Backend**: 15+ modules with clean architecture
-- **Frontend**: 20+ components with modern React patterns
-- **API**: 15+ endpoints with comprehensive validation
-- **Tests**: 50+ test cases with good coverage
-- **Documentation**: 4 comprehensive guides
-- **Security**: Multiple layers of protection
+- **Docker Compose** (local `db` service on port 5433)
+- **Nginx** reverse proxy (including WebSocket upgrade for `/socket.io`)
+- **Supabase** connection pooling in production
 
 ## 🤝 Contributing
 
-To contribute to this project:
-
-1. **Read the [Developer Guide](./DEVELOPER_GUIDE.md)** for setup instructions
-2. **Follow the architecture patterns** described in the [Architecture Documentation](./ARCHITECTURE.md)
-3. **Write tests** for new features
-4. **Update documentation** as needed
-5. **Submit pull requests** following the established workflow
-
-## 🆘 Support
-
-If you need help:
-
-1. **Check the documentation** - Most questions are answered here
-2. **Review the examples** - Each guide includes practical examples
-3. **Check the code** - The codebase follows the patterns described in the docs
-4. **Create an issue** - For bugs or feature requests
-5. **Ask questions** - Use the project's communication channels
+1. Read the [Developer Guide](./DEVELOPER_GUIDE.md)
+2. Follow patterns in [Architecture Documentation](./ARCHITECTURE.md)
+3. Keep `packages/types` in sync when changing API or realtime contracts
+4. Write tests and update docs with your changes
 
 ## 📈 Roadmap
 
-### Planned Documentation Updates
+### Documentation
 
-- [ ] **Performance Optimization Guide** - Advanced performance tuning
-- [ ] **Security Best Practices** - Comprehensive security guidelines
-- [ ] **Monitoring and Alerting** - Production monitoring setup
-- [ ] **API Versioning Guide** - Managing API evolution
-- [ ] **Testing Strategies** - Advanced testing patterns
-- [ ] **CI/CD Pipeline** - Automated deployment workflows
+- [x] **Performance Optimization Guide** — [PERFORMANCE.md](./PERFORMANCE.md)
+- [ ] **Security Best Practices** — comprehensive security guidelines
+- [ ] **Monitoring and Alerting** — production monitoring setup
+- [ ] **API Versioning Guide** — managing API evolution
+- [ ] **Testing Strategies** — advanced testing patterns
+- [ ] **CI/CD Pipeline** — automated deployment workflows
 
-### Planned Features
+### Features
 
-- [ ] **User Authentication** - JWT-based authentication system
-- [ ] **Real-time Updates** - WebSocket integration
-- [ ] **Advanced Analytics** - Betting analytics and reporting
-- [ ] **Mobile App** - React Native mobile application
-- [ ] **Payment Integration** - Payment processing capabilities
-- [ ] **Admin Dashboard** - Enhanced admin interface
-
-## 📝 Documentation Standards
-
-This documentation follows these standards:
-
-- **Clear Structure** - Logical organization and navigation
-- **Practical Examples** - Real code examples and use cases
-- **Comprehensive Coverage** - All aspects of the system documented
-- **Up-to-date Content** - Regular updates with code changes
-- **Easy to Follow** - Step-by-step instructions and explanations
-
-## 🏆 Best Practices Highlighted
-
-### Code Quality
-
-- **Clean Architecture** principles
-- **SOLID** design principles
-- **DRY** (Don't Repeat Yourself)
-- **Separation of Concerns**
-- **Dependency Injection**
-
-### Security
-
-- **Input Validation** and sanitization
-- **Rate Limiting** and abuse prevention
-- **Security Headers** implementation
-- **Error Handling** without information leakage
-- **Authentication** and authorization patterns
-
-### Performance
-
-- **Database Optimization** with proper indexing
-- **Caching Strategies** for frequently accessed data
-- **Bundle Optimization** for frontend assets
-- **Connection Pooling** for database connections
-- **Monitoring** and performance tracking
-
-### Maintainability
-
-- **Comprehensive Testing** with good coverage
-- **Clear Documentation** for all components
-- **Consistent Code Style** and formatting
-- **Modular Architecture** for easy updates
-- **Version Control** best practices
+- [x] **Real-time Updates** — Socket.io (see [ARCHITECTURE.md](./ARCHITECTURE.md) and [API.md](./API.md))
+- [ ] **User Authentication** — end-user JWT (admin JWT exists today)
+- [ ] **Advanced Analytics** — betting analytics and reporting
+- [ ] **Mobile App** — React Native mobile application
+- [ ] **Payment Integration** — payment processing capabilities
+- [ ] **Admin Dashboard** — enhanced admin interface
 
 ---
 
 **Happy coding!** 🚀
 
-This documentation is designed to help you understand, develop, and deploy the SarradaBet platform successfully. If you have suggestions for improvements or additional documentation needs, please contribute to the project!
+For quick local setup, start with the [Main README](../README.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
       "devDependencies": {
         "jest": "^30.2.0",
         "prettier": "^3.5.3",
-        "turbo": "^2.6.1",
+        "turbo": "^2.9.18",
         "typescript": "5.9.3",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.6"
       },
       "engines": {
         "node": ">=20"
@@ -61,7 +61,7 @@
         "@prisma/client": "^6.19.0",
         "@sarradabet/types": "*",
         "@types/express": "^5.0.0",
-        "axios": "^1.7.9",
+        "axios": "^1.18.0",
         "bcryptjs": "^3.0.3",
         "compression": "^1.8.0",
         "consul": "^1.2.0",
@@ -122,15 +122,15 @@
         "@headlessui/react": "^2.2.0",
         "@sarradabet/types": "*",
         "@sarradahub/design-system": "file:../../../platform/design-system",
-        "axios": "^1.13.2",
+        "axios": "^1.18.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "didyoumean": "^1.2.2",
         "lucide-react": "^0.525.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router": "^7.9.6",
-        "react-router-dom": "^7.9.6",
+        "react-router": "^7.17.0",
+        "react-router-dom": "^7.17.0",
         "set-cookie-parser": "^2.7.2",
         "socket.io-client": "^4.8.1",
         "tailwind-merge": "^3.3.1"
@@ -144,7 +144,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^3.2.4",
+        "@vitest/coverage-v8": "^3.2.6",
         "autoprefixer": "^10.4.21",
         "dlv": "^1.1.3",
         "eslint": "^9.39.1",
@@ -153,7 +153,6 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^15.15.0",
-        "happy-dom": "^17.6.3",
         "jsdom": "^27.2.0",
         "object-hash": "^3.0.0",
         "postcss": "^8.5.3",
@@ -166,7 +165,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.47.0",
         "vite": "^7.1.9",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.6"
       }
     },
     "apps/web/node_modules/globals": {
@@ -1030,9 +1029,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1047,9 +1046,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -1064,9 +1063,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1081,9 +1080,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1098,9 +1097,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1115,9 +1114,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1132,9 +1131,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1149,9 +1148,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1166,9 +1165,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -1183,9 +1182,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -1200,9 +1199,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -1217,9 +1216,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1234,9 +1233,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1251,9 +1250,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1268,9 +1267,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1285,9 +1284,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1302,9 +1301,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1319,9 +1318,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1336,9 +1335,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1353,9 +1352,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1370,9 +1369,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1387,9 +1386,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1404,9 +1403,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1421,9 +1420,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1438,9 +1437,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1455,9 +1454,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1632,33 +1631,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.5.0.tgz",
-      "integrity": "sha512-rSXBsAcmx80jI9OUevyNBU0f5pZRQJkNmk4bLX6hCbm1qKe5Z/TcU7vwXc2nR8814mhRlgbZIHL1+HSiYS0VkQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.0.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-PRfWP+8FOldvbApr6xL7mNCw4cJcSTq4GA7tYbgq15mRb0kWKO/wEB2jr+uwjFH3sZvEZneZyCUGTxsv4Sahyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@faker-js/faker": {
@@ -2361,60 +2333,60 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
-      "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.21.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.0.tgz",
-      "integrity": "sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.0.tgz",
-      "integrity": "sha512-pMRJ+1S6NVdXoB8QJAPIGpKZevFjxhKt0paCkRDTZiczKb7F4yTgRP8M4JdVkpQwmaD4EoJf6qA+p61godDokw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.0",
-        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-        "@prisma/fetch-engine": "6.19.0",
-        "@prisma/get-platform": "6.19.0"
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773.tgz",
-      "integrity": "sha512-gV7uOBQfAFlWDvPJdQxMT1aSRur3a0EkU/6cfbAC5isV67tKDWUrPauyaHNpB+wN1ebM4A9jn/f4gH+3iHSYSQ==",
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.0.tgz",
-      "integrity": "sha512-OOx2Lda0DGrZ1rodADT06ZGqHzr7HY7LNMaFE2Vp8dp146uJld58sRuasdX0OiwpHgl8SqDTUKHNUyzEq7pDdQ==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.0",
-        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-        "@prisma/get-platform": "6.19.0"
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.0.tgz",
-      "integrity": "sha512-ym85WDO2yDhC3fIXHWYpG3kVMBA49cL1XD2GCsCF8xbwoy2OkDQY44gEbAt2X46IQ4Apq9H6g0Ex1iFfPqEkHA==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.19.0"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@react-aria/focus": {
@@ -2522,9 +2494,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -2536,9 +2508,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -2550,9 +2522,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -2564,9 +2536,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -2578,9 +2550,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -2592,9 +2564,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -2606,9 +2578,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
@@ -2620,9 +2592,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
@@ -2634,9 +2606,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
@@ -2648,9 +2620,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
@@ -2662,9 +2634,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
       ],
@@ -2676,9 +2662,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
       ],
@@ -2690,9 +2690,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
@@ -2704,9 +2704,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
@@ -2718,9 +2718,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
@@ -2732,9 +2732,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
@@ -2746,9 +2746,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
@@ -2759,10 +2759,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
       "cpu": [
         "arm64"
       ],
@@ -2774,9 +2788,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -2788,9 +2802,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -2802,9 +2816,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
       "cpu": [
         "x64"
       ],
@@ -2816,9 +2830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -2881,9 +2895,9 @@
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3089,6 +3103,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.18.tgz",
+      "integrity": "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.18.tgz",
+      "integrity": "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.18.tgz",
+      "integrity": "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.18.tgz",
+      "integrity": "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.18.tgz",
+      "integrity": "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.18.tgz",
+      "integrity": "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3229,9 +3327,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3700,6 +3798,32 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4053,9 +4177,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4077,8 +4201,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4096,16 +4220,70 @@
         "node": ">=18"
       }
     },
+    "node_modules/@vitest/coverage-v8/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -4114,13 +4292,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4141,9 +4319,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4154,13 +4332,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -4169,13 +4347,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -4184,9 +4362,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4197,13 +4375,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -4271,9 +4449,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4553,21 +4731,21 @@
       "license": "MIT"
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
-      "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4658,14 +4836,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -4854,23 +5058,23 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -4886,16 +5090,45 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5205,9 +5438,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5567,9 +5800,9 @@
       "license": "MIT"
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -5939,9 +6172,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -6016,9 +6249,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6102,9 +6335,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -6460,9 +6693,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6473,32 +6706,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6734,6 +6967,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6959,39 +7206,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -7005,12 +7252,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7263,9 +7510,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7276,9 +7523,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -7564,19 +7811,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/giget": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
@@ -7685,9 +7919,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7704,20 +7938,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/happy-dom": {
-      "version": "17.6.3",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.6.3.tgz",
-      "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0",
-        "whatwg-mimetype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -8024,9 +8244,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9134,9 +9354,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9436,12 +9656,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -9864,9 +10084,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9958,9 +10178,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -10146,23 +10366,27 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
+      "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10575,9 +10799,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -10610,9 +10834,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10656,13 +10880,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -10677,9 +10901,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -10697,7 +10921,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10894,14 +11118,14 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.0.tgz",
-      "integrity": "sha512-F3eX7K+tWpkbhl3l4+VkFtrwJlLXbAM+f9jolgoUZbFcm1DgHZ4cq9AgVEgUym2au5Ad/TDLN8lg83D+M10ycw==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.0",
-        "@prisma/engines": "6.19.0"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -10951,10 +11175,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -10991,12 +11218,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -11036,16 +11263,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -11099,9 +11355,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.6.tgz",
-      "integrity": "sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -11121,12 +11377,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.6.tgz",
-      "integrity": "sha512-2MkC2XSXq6HjGcihnx1s0DBWQETI4mlis4Ux7YTLvP67xnGxCvq+BcCQSO81qQHVUTM1V53tl4iVVaY5sReCOA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.6"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11304,16 +11560,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -11326,13 +11572,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -11342,28 +11588,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -12574,9 +12823,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12618,9 +12867,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12911,14 +13160,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -12931,106 +13179,22 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.6.1.tgz",
-      "integrity": "sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.18.tgz",
+      "integrity": "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.6.1",
-        "turbo-darwin-arm64": "2.6.1",
-        "turbo-linux-64": "2.6.1",
-        "turbo-linux-arm64": "2.6.1",
-        "turbo-windows-64": "2.6.1",
-        "turbo-windows-arm64": "2.6.1"
+        "@turbo/darwin-64": "2.9.18",
+        "@turbo/darwin-arm64": "2.9.18",
+        "@turbo/linux-64": "2.9.18",
+        "@turbo/linux-arm64": "2.9.18",
+        "@turbo/windows-64": "2.9.18",
+        "@turbo/windows-arm64": "2.9.18"
       }
-    },
-    "node_modules/turbo-darwin-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.6.1.tgz",
-      "integrity": "sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-darwin-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.6.1.tgz",
-      "integrity": "sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-linux-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.6.1.tgz",
-      "integrity": "sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-linux-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.6.1.tgz",
-      "integrity": "sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-windows-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.6.1.tgz",
-      "integrity": "sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/turbo-windows-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.6.1.tgz",
-      "integrity": "sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -13385,13 +13549,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
-      "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -13501,9 +13665,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13514,20 +13678,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -13557,8 +13721,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -13587,9 +13751,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13633,16 +13797,6 @@
       "resolved": "apps/web",
       "link": true
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -13667,16 +13821,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/whatwg-url": {
@@ -13995,9 +14139,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,11 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.19.0",
+        "@sarradabet/types": "*",
         "@types/express": "^5.0.0",
         "axios": "^1.7.9",
         "bcryptjs": "^3.0.3",
+        "compression": "^1.8.0",
         "consul": "^1.2.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -71,8 +73,10 @@
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "node-cache": "^5.1.2",
         "opossum": "^7.0.0",
         "prisma": "^6.19.0",
+        "socket.io": "^4.8.1",
         "winston": "^3.17.0",
         "zod": "^3.24.2"
       },
@@ -80,6 +84,7 @@
         "@eslint/js": "^9.39.1",
         "@faker-js/faker": "^9.0.0",
         "@types/bcryptjs": "^3.0.0",
+        "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.17",
         "@types/express-rate-limit": "^5.1.3",
         "@types/jest": "^30.0.0",
@@ -115,6 +120,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@headlessui/react": "^2.2.0",
+        "@sarradabet/types": "*",
         "@sarradahub/design-system": "file:../../../platform/design-system",
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
@@ -126,6 +132,7 @@
         "react-router": "^7.9.6",
         "react-router-dom": "^7.9.6",
         "set-cookie-parser": "^2.7.2",
+        "socket.io-client": "^4.8.1",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -2822,6 +2829,10 @@
         "win32"
       ]
     },
+    "node_modules/@sarradabet/types": {
+      "resolved": "packages/types",
+      "link": true
+    },
     "node_modules/@sarradahub/design-system": {
       "resolved": "../platform/design-system",
       "link": true
@@ -2862,6 +2873,12 @@
         "color": "^5.0.2",
         "text-hex": "1.0.x"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -3168,6 +3185,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3188,7 +3216,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3456,6 +3483,15 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4748,6 +4784,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.30",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
@@ -5317,6 +5362,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5449,6 +5503,60 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -5723,7 +5831,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6053,6 +6160,100 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/entities": {
@@ -9814,6 +10015,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -11570,6 +11783,83 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.20.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/source-map": {
@@ -13743,6 +14033,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -13864,6 +14162,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/types": {
+      "name": "@sarradabet/types",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.9.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "turbo run dev --parallel",
     "build": "npm run build:design-system && turbo run build",
-    "build:design-system": "cd ../platform/design-system && npm ci --legacy-peer-deps && npm run build",
+    "build:design-system": "bash scripts/clone-platform.sh && cd ../platform/design-system && npm ci --legacy-peer-deps && npm run build",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "devDependencies": {
     "prettier": "^3.5.3",
-    "turbo": "^2.6.1",
+    "turbo": "^2.9.18",
     "typescript": "5.9.3",
-    "vitest": "^3.2.4",
+    "vitest": "^3.2.6",
     "jest": "^30.2.0"
   },
   "engines": {
@@ -44,13 +44,14 @@
   "overrides": {
     "on-headers": ">=1.1.0",
     "@eslint/plugin-kit": ">=0.3.4",
-    "minimatch": "^3.1.2",
+    "esbuild": ">=0.28.1",
+    "minimatch": "^3.1.5",
     "test-exclude": {
-      "minimatch": "^3.1.2"
+      "minimatch": "^3.1.5"
     },
     "@vitest/coverage-v8": {
       "test-exclude": "^6.0.0",
-      "minimatch": "^3.1.2"
+      "minimatch": "^3.1.5"
     }
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sarradabet/types",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/types/src/bet.ts
+++ b/packages/types/src/bet.ts
@@ -1,0 +1,51 @@
+export type BetStatus = "open" | "closed" | "resolved";
+export type OddResult = "pending" | "won" | "lost";
+
+export type OddWithVotes = {
+  id: number;
+  title: string;
+  value: number;
+  totalVotes: number;
+};
+
+export type OddDetail = OddWithVotes & {
+  result?: OddResult;
+  betId?: number;
+};
+
+export type CategoryRef = {
+  id: number;
+  title: string;
+};
+
+export type BetListItem = {
+  id: number;
+  title: string;
+  description?: string | null;
+  status: BetStatus;
+  categoryId: number;
+  category?: CategoryRef;
+  odds: OddWithVotes[];
+  totalVotes: number;
+  createdAt: string | Date;
+};
+
+export type BetDetail = BetListItem & {
+  updatedAt: string | Date;
+  resolvedAt?: string | Date | null;
+  odds: OddDetail[];
+};
+
+export type CreateBetDto = {
+  title: string;
+  description?: string;
+  categoryId: number;
+  odds: Array<{
+    title: string;
+    value: number;
+  }>;
+};
+
+export type UpdateBetDto = Partial<CreateBetDto> & {
+  status?: BetStatus;
+};

--- a/packages/types/src/category.ts
+++ b/packages/types/src/category.ts
@@ -1,0 +1,15 @@
+export type Category = {
+  id: number;
+  title: string;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+  _count?: {
+    bet: number;
+  };
+};
+
+export type CreateCategoryDto = {
+  title: string;
+};
+
+export type UpdateCategoryDto = Partial<CreateCategoryDto>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,8 +1,3 @@
-export type Bet = {
-  id: number;
-  title: string;
-  description?: string;
-  status: "open" | "closed" | "resolved";
-  createdAt: Date;
-  updatedAt: Date;
-};
+export * from "./bet";
+export * from "./category";
+export * from "./realtime";

--- a/packages/types/src/package.json
+++ b/packages/types/src/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "shared",
-  "version": "1.0.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "devDependencies": {
-    "typescript": "^5.0.2"
-  }
-}

--- a/packages/types/src/realtime.ts
+++ b/packages/types/src/realtime.ts
@@ -1,0 +1,27 @@
+import type { BetListItem } from "./bet";
+
+export const RealtimeEvents = {
+  VOTE_CREATED: "vote:created",
+  BET_CREATED: "bet:created",
+  BET_UPDATED: "bet:updated",
+} as const;
+
+export type RealtimeEventName =
+  (typeof RealtimeEvents)[keyof typeof RealtimeEvents];
+
+export type VoteCreatedPayload = {
+  betId: number;
+  oddId: number;
+  odds: { id: number; totalVotes: number }[];
+  totalVotes: number;
+};
+
+export type BetCreatedPayload = BetListItem;
+
+export type BetUpdatedPayload = BetListItem;
+
+export type RealtimePayloadMap = {
+  [RealtimeEvents.VOTE_CREATED]: VoteCreatedPayload;
+  [RealtimeEvents.BET_CREATED]: BetCreatedPayload;
+  [RealtimeEvents.BET_UPDATED]: BetUpdatedPayload;
+};

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../config/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}

--- a/scripts/clone-platform.sh
+++ b/scripts/clone-platform.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_repo_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/turbo.json" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
+PLATFORM_DIR="$(dirname "$REPO_ROOT")/platform"
+DESIGN_SYSTEM_DIR="$PLATFORM_DIR/design-system"
+
+if [ -f "$DESIGN_SYSTEM_DIR/package.json" ]; then
+  echo "platform/design-system already present at $DESIGN_SYSTEM_DIR"
+  exit 0
+fi
+
+echo "Cloning SarradaHub/platform into $PLATFORM_DIR..."
+git clone --depth 1 https://github.com/SarradaHub/platform.git "$PLATFORM_DIR"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
-  "installCommand": "cd ../.. && bash scripts/clone-platform.sh && npm ci",
-  "buildCommand": "cd ../.. && npm run build:design-system && npm run -w web build",
-  "outputDirectory": "dist",
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "bash scripts/clone-platform.sh && npm ci",
+  "buildCommand": "npm run build:design-system && turbo run build --filter=web",
+  "outputDirectory": "apps/web/dist",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
## Real-time betting: Socket.io push, caching, and performance refactor

### Summary

- **Realtime layer:** Socket.io on the API (`vote:created`, `bet:created`, `bet:updated`); web `RealtimeProvider` + `useSocket` patch query cache; vote flow drops post-vote REST refetch (3 RTTs → 1 + push).
- **Performance:** Backend `node-cache`, gzip compression, slim bet list DTOs, Prisma indexes on `categoryId` and `(status, created_at)`; optimistic votes, skeleton loaders, and lazy admin routes on web.
- **Shared contracts & docs:** `@sarradabet/types` wired into api/web; `.env.example` files; README + full `docs/` refresh (API, architecture, deployment, performance guide).

### What changed

#### Backend (`apps/api`)

- Socket.io on HTTP server (`server.ts`, `realtime/`)
- Emit on vote create and bet create/update/close/resolve
- `node-cache` for categories, resolved bets, and bet detail
- `Cache-Control` on `GET /api/v1/categories`
- `bet.mapper.ts` — `BetListItem` vs `BetDetail`
- Shared Prisma client in legacy repos; vote repo returns aggregated odds in one transaction
- Migration: `20250614000000_add_bet_performance_indexes`

#### Frontend (`apps/web`)

- `RealtimeProvider`, `useSocket`, cache patch on socket events
- Optimistic voting in `OddsList`; `BetCard` uses `bet.category` (N+1 removed)
- `BetCardSkeleton`, lazy admin routes, `vercel.json`
- Vite dev proxy for `/socket.io`

#### Shared (`packages/types`)

- `BetListItem`, `BetDetail`, `RealtimeEvents`, category types

#### Dev experience

- `apps/api/.env.example` + `apps/web/.env.example` (includes required `DIRECT_URL`)
- Local defaults: API **8000**, web **3002**, Postgres **5433**, Docker service **`db`**

### Performance impact

| Action | Before | After |
|--------|--------|-------|
| Vote (self) | POST + GET bet + GET category | POST + optimistic UI; socket confirms |
| Vote (other users) | Stale until refresh | Socket push |
| Bet list payload | Full odd entities | Slim DTO + gzip |

### Deployment notes

- Set `CORS_ORIGINS` to include the frontend origin (required for Socket.io).
- Supabase: `DATABASE_URL` (pooler `:6543?pgbouncer=true`) + `DIRECT_URL` (`:5432`).
- nginx: proxy `/socket.io/` with WebSocket upgrade (see `docs/DEPLOYMENT.md`).
- Single Render instance is fine for Socket.io; multi-instance needs Redis adapter (see `docs/PERFORMANCE.md`).

### Test plan

- [ ] `docker compose up -d db` → `npm run prisma:migrate:dev` → `npm run dev`
- [ ] Open http://localhost:3002 in two browsers; vote in one; counts update in both without refresh
- [ ] DevTools: after vote, only `POST /api/v1/votes` (no `GET /bets/:id` or per-card category fetch)
- [ ] Socket listener receives `vote:created` on `POST /votes` (see `docs/PERFORMANCE.md`)
- [ ] `curl -D - http://localhost:8000/api/v1/categories` → `Cache-Control` present
- [ ] Stop API, vote again → optimistic count rolls back + error in UI
- [ ] `npm run test:api`
- [ ] `npm run test:web`
- [ ] `cd apps/api && npm run build` and `cd apps/web && npm run build`