### PR TITLE
feat(admin): add coin adjust API, audit log, and admin UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,9 +141,10 @@ Base: `http://localhost:8000/api/v1`. Full reference: [`docs/API.md`](docs/API.m
 | GET | `/users/me/dashboard` | Required | User dashboard |
 | POST | `/rewards/:id/redeem` | Required | Generates ticket |
 | GET/POST | `/admin/rewards`, `/admin/analytics/*` | Admin | CRUD + analytics |
+| POST | `/admin/users/:id/coins/adjust` | Admin | Credit/debit + audit log |
 | POST | `/webhooks/mercadopago` | MP HMAC | No JWT |
 
-**Not shipped (Planned — Feature 06):** `PATCH /admin/users/:id/ban`, `POST /admin/users/:id/coins/adjust`, `GET /admin/payments/pix`.
+**Not shipped (Planned — Feature 06):** `PATCH /admin/users/:id/ban`, `GET /admin/payments/pix`.
 
 ### Socket.io events
 
@@ -286,6 +287,7 @@ Shipped behavior lives in living docs — not in deleted feature guides 01–05/
 
 | Date | Change |
 |------|--------|
+| 2026-08-13 | Shipped admin coin adjust API + UI (`ADMIN_ADJUSTMENT`, `AdminAuditLog`) |
 | 2026-08-13 | Shipped dark/light mode toggle (ThemeProvider, ThemeToggle, dual CSS palette) |
 | 2026-08-09 | Docs cleanup: deleted feature guides 01–05/07; added ROADMAP; refreshed living docs; rewrote AGENTS.md |
 | — | Shipped: auth, coins/Pix, bet payout, gamification, analytics, instore QR |

--- a/apps/api/prisma/migrations/20260813220000_add_admin_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20260813220000_add_admin_audit_log/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "admin_audit_logs" (
+    "id" SERIAL NOT NULL,
+    "admin_id" INTEGER NOT NULL,
+    "action" TEXT NOT NULL,
+    "target_user_id" INTEGER NOT NULL,
+    "payload" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_admin_id_idx" ON "admin_audit_logs"("admin_id");
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_target_user_id_idx" ON "admin_audit_logs"("target_user_id");
+
+-- AddForeignKey
+ALTER TABLE "admin_audit_logs" ADD CONSTRAINT "admin_audit_logs_admin_id_fkey" FOREIGN KEY ("admin_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "admin_audit_logs" ADD CONSTRAINT "admin_audit_logs_target_user_id_fkey" FOREIGN KEY ("target_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -94,10 +94,28 @@ model User {
   votes             Vote[]
   stats             UserStats?
   rewardRedemptions RewardRedemption[]
+  adminAuditLogs    AdminAuditLog[]    @relation("AdminAuditLogs")
+  targetAuditLogs   AdminAuditLog[]    @relation("TargetAuditLogs")
   createdAt         DateTime           @default(now()) @map("created_at")
   updatedAt         DateTime           @updatedAt @map("updated_at")
 
   @@map("users")
+}
+
+model AdminAuditLog {
+  id           Int      @id @default(autoincrement())
+  adminId      Int      @map("admin_id")
+  action       String
+  targetUserId Int      @map("target_user_id")
+  payload      Json
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  admin      User @relation("AdminAuditLogs", fields: [adminId], references: [id])
+  targetUser User @relation("TargetAuditLogs", fields: [targetUserId], references: [id])
+
+  @@index([adminId])
+  @@index([targetUserId])
+  @@map("admin_audit_logs")
 }
 
 model UserStats {

--- a/apps/api/src/__tests__/helpers/authTestHelper.ts
+++ b/apps/api/src/__tests__/helpers/authTestHelper.ts
@@ -78,6 +78,7 @@ export const loginTestUser = async (
 
 export const cleanupAuthData = async (prisma: PrismaClient): Promise<void> => {
   await prisma.pixPayment.deleteMany();
+  await prisma.adminAuditLog.deleteMany();
   await prisma.coinTransaction.deleteMany();
   await prisma.vote.deleteMany();
   await prisma.odd.deleteMany();

--- a/apps/api/src/__tests__/integration/admin.coins.adjust.test.ts
+++ b/apps/api/src/__tests__/integration/admin.coins.adjust.test.ts
@@ -1,0 +1,220 @@
+const testDbUrl = (() => {
+  const url =
+    process.env.DATABASE_URL ||
+    "postgresql://appuser:sarradabet1234@localhost:5433/sarradabet_test";
+
+  if (url.includes("/sarradabet") && !url.includes("/sarradabet_test")) {
+    return url.replace("/sarradabet", "/sarradabet_test");
+  }
+
+  return url;
+})();
+
+process.env.DATABASE_URL = testDbUrl;
+process.env.JWT_SECRET = "test-secret";
+
+import {
+  CoinTransactionSource,
+  PrismaClient,
+  UserRole,
+} from "@prisma/client";
+import request from "supertest";
+import { app } from "../../app";
+import {
+  authHeader,
+  checkDatabaseConnection,
+  cleanupAuthData,
+  createTestUser,
+  testIfDbAvailable,
+  uniqueTestPhone,
+} from "../helpers/authTestHelper";
+
+let prisma: PrismaClient | null = null;
+let isDatabaseAvailable = false;
+
+describe("Admin Coin Adjust Routes", () => {
+  beforeAll(async () => {
+    isDatabaseAvailable = await checkDatabaseConnection(testDbUrl);
+    if (!isDatabaseAvailable) return;
+
+    prisma = new PrismaClient({
+      datasources: { db: { url: testDbUrl } },
+    });
+    await cleanupAuthData(prisma);
+  });
+
+  afterAll(async () => {
+    if (prisma) {
+      await prisma.$disconnect();
+      prisma = null;
+    }
+  });
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return 401 without authentication",
+    async () => {
+      await request(app)
+        .post("/api/v1/admin/users/1/coins/adjust")
+        .send({ amount: 10, direction: "credit", reason: "Test credit" })
+        .expect(401);
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return 403 for non-admin users",
+    async () => {
+      if (!prisma) return;
+
+      const user = await createTestUser(prisma, {
+        username: "regularuser",
+        email: "regularuser@example.com",
+        phone: uniqueTestPhone(888801),
+        role: UserRole.USER,
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: user.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      await request(app)
+        .post(`/api/v1/admin/users/${user.id}/coins/adjust`)
+        .set(authHeader(token))
+        .send({ amount: 10, direction: "credit", reason: "Test credit" })
+        .expect(403);
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should credit coins and create audit log for admin",
+    async () => {
+      if (!prisma) return;
+
+      const admin = await createTestUser(prisma, {
+        username: "coinadjustadmin",
+        email: "coinadjustadmin@example.com",
+        phone: uniqueTestPhone(888802),
+        role: UserRole.ADMIN,
+      });
+
+      const target = await createTestUser(prisma, {
+        username: "cointarget",
+        email: "cointarget@example.com",
+        phone: uniqueTestPhone(888803),
+        role: UserRole.USER,
+      });
+
+      await prisma.user.update({
+        where: { id: target.id },
+        data: { coinBalance: 50 },
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: admin.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      const response = await request(app)
+        .post(`/api/v1/admin/users/${target.id}/coins/adjust`)
+        .set(authHeader(token))
+        .send({
+          amount: 100,
+          direction: "credit",
+          reason: "Promotional bonus",
+        })
+        .expect(200);
+
+      expect(response.body.data.balance).toBe(150);
+      expect(response.body.data.transactionId).toBeDefined();
+
+      const updatedUser = await prisma.user.findUniqueOrThrow({
+        where: { id: target.id },
+      });
+      expect(updatedUser.coinBalance).toBe(150);
+
+      const transaction = await prisma.coinTransaction.findFirst({
+        where: {
+          id: response.body.data.transactionId,
+          userId: target.id,
+        },
+      });
+      expect(transaction?.source).toBe(CoinTransactionSource.ADMIN_ADJUSTMENT);
+      expect(transaction?.description).toBe("Promotional bonus");
+      expect(transaction?.referenceId).toBe(admin.id);
+
+      const auditLog = await prisma.adminAuditLog.findFirst({
+        where: { targetUserId: target.id, adminId: admin.id },
+      });
+      expect(auditLog).not.toBeNull();
+      expect(auditLog?.action).toBe("COIN_ADJUST");
+      expect(auditLog?.payload).toMatchObject({
+        amount: 100,
+        direction: "credit",
+        reason: "Promotional bonus",
+        balanceBefore: 50,
+        balanceAfter: 150,
+      });
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should reject debit exceeding balance without partial update",
+    async () => {
+      if (!prisma) return;
+
+      const admin = await createTestUser(prisma, {
+        username: "coinadjustadmin2",
+        email: "coinadjustadmin2@example.com",
+        phone: uniqueTestPhone(888804),
+        role: UserRole.ADMIN,
+      });
+
+      const target = await createTestUser(prisma, {
+        username: "cointarget2",
+        email: "cointarget2@example.com",
+        phone: uniqueTestPhone(888805),
+        role: UserRole.USER,
+      });
+
+      await prisma.user.update({
+        where: { id: target.id },
+        data: { coinBalance: 30 },
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: admin.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      await request(app)
+        .post(`/api/v1/admin/users/${target.id}/coins/adjust`)
+        .set(authHeader(token))
+        .send({
+          amount: 50,
+          direction: "debit",
+          reason: "Correction for overpayment",
+        })
+        .expect(400);
+
+      const updatedUser = await prisma.user.findUniqueOrThrow({
+        where: { id: target.id },
+      });
+      expect(updatedUser.coinBalance).toBe(30);
+
+      const auditCount = await prisma.adminAuditLog.count({
+        where: { targetUserId: target.id },
+      });
+      expect(auditCount).toBe(0);
+    },
+  );
+});

--- a/apps/api/src/core/validation/ValidationSchemas.ts
+++ b/apps/api/src/core/validation/ValidationSchemas.ts
@@ -238,6 +238,21 @@ export const CreateCoinPackageSchema = z.object({
 
 export const UpdateCoinPackageSchema = CreateCoinPackageSchema.partial();
 
+export const AdjustCoinsSchema = z.object({
+  amount: z
+    .number()
+    .int("Amount must be an integer")
+    .positive("Amount must be greater than zero"),
+  direction: z.enum(["credit", "debit"], {
+    errorMap: () => ({ message: "Direction must be credit or debit" }),
+  }),
+  reason: z
+    .string()
+    .min(3, "Reason must be at least 3 characters")
+    .max(500, "Reason cannot exceed 500 characters")
+    .trim(),
+});
+
 export const CreatePixPurchaseSchema = z.object({
   coinPackageId: IdSchema,
 });
@@ -330,6 +345,7 @@ export type UserLoginInput = z.infer<typeof UserLoginSchema>;
 export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;
 export type CreateCoinPackageInput = z.infer<typeof CreateCoinPackageSchema>;
 export type UpdateCoinPackageInput = z.infer<typeof UpdateCoinPackageSchema>;
+export type AdjustCoinsInput = z.infer<typeof AdjustCoinsSchema>;
 export type CreatePixPurchaseInput = z.infer<typeof CreatePixPurchaseSchema>;
 export type CreateRewardInput = z.infer<typeof CreateRewardSchema>;
 export type UpdateRewardInput = z.infer<typeof UpdateRewardSchema>;

--- a/apps/api/src/modules/admin/controllers/AdminCoinController.ts
+++ b/apps/api/src/modules/admin/controllers/AdminCoinController.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response } from "express";
+import { BadRequestError } from "../../../core/errors/AppError";
+import { RequestUser } from "../../../core/middleware/AuthMiddleware";
+import { ApiResponse } from "../../../utils/api/response";
+import { AdminCoinService } from "../services/AdminCoinService";
+
+export class AdminCoinController {
+  constructor(private readonly adminCoinService: AdminCoinService = new AdminCoinService()) {}
+
+  adjust = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const targetUserId = Number.parseInt(req.params.id, 10);
+      if (Number.isNaN(targetUserId) || targetUserId <= 0) {
+        throw new BadRequestError("Invalid user ID provided");
+      }
+
+      const admin = req.user as Extract<RequestUser, { type: "user" }> | undefined;
+      if (!admin) {
+        throw new BadRequestError("Authenticated admin required");
+      }
+
+      const result = await this.adminCoinService.adjustBalance(
+        admin.userId,
+        targetUserId,
+        req.body,
+      );
+      new ApiResponse(res).success({ ...result });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/apps/api/src/modules/admin/repositories/AdminAuditLogRepository.ts
+++ b/apps/api/src/modules/admin/repositories/AdminAuditLogRepository.ts
@@ -1,0 +1,17 @@
+import { AdminAuditLog, Prisma } from "@prisma/client";
+
+export interface CreateAdminAuditLogData {
+  adminId: number;
+  action: string;
+  targetUserId: number;
+  payload: Prisma.InputJsonValue;
+}
+
+export class AdminAuditLogRepository {
+  async create(
+    tx: Prisma.TransactionClient,
+    data: CreateAdminAuditLogData,
+  ): Promise<AdminAuditLog> {
+    return tx.adminAuditLog.create({ data });
+  }
+}

--- a/apps/api/src/modules/admin/routes/admin.users.routes.ts
+++ b/apps/api/src/modules/admin/routes/admin.users.routes.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { UserRole } from "@prisma/client";
+import {
+  authenticateUser,
+  requireUserRole,
+} from "../../../core/middleware/AuthMiddleware";
+import {
+  validateBody,
+  validateParams,
+} from "../../../core/middleware/ValidationMiddleware";
+import {
+  AdjustCoinsSchema,
+  ParamIdSchema,
+} from "../../../core/validation/ValidationSchemas";
+import { AdminCoinController } from "../controllers/AdminCoinController";
+
+const adminCoinController = new AdminCoinController();
+
+const router = Router();
+
+router.use(authenticateUser, requireUserRole(UserRole.ADMIN));
+
+router.post(
+  "/:id/coins/adjust",
+  validateParams(ParamIdSchema),
+  validateBody(AdjustCoinsSchema),
+  adminCoinController.adjust,
+);
+
+export default router;

--- a/apps/api/src/modules/admin/services/AdminCoinService.ts
+++ b/apps/api/src/modules/admin/services/AdminCoinService.ts
@@ -1,0 +1,68 @@
+import { CoinTransactionSource } from "@prisma/client";
+import type { AdjustCoinsRequest, AdjustCoinsResponse } from "@sarradabet/types";
+import { prisma } from "../../../config/db";
+import { NotFoundError } from "../../../core/errors/AppError";
+import { CoinService } from "../../coin/services/CoinService";
+import { AdminAuditLogRepository } from "../repositories/AdminAuditLogRepository";
+
+export class AdminCoinService {
+  constructor(
+    private readonly coinService: CoinService = new CoinService(),
+    private readonly auditRepo: AdminAuditLogRepository = new AdminAuditLogRepository(),
+  ) {}
+
+  async adjustBalance(
+    adminId: number,
+    targetUserId: number,
+    dto: AdjustCoinsRequest,
+  ): Promise<AdjustCoinsResponse> {
+    return prisma.$transaction(async (tx) => {
+      const user = await tx.user.findUnique({ where: { id: targetUserId } });
+      if (!user) {
+        throw new NotFoundError("User not found");
+      }
+
+      const balanceBefore = user.coinBalance;
+
+      const metadata = {
+        source: CoinTransactionSource.ADMIN_ADJUSTMENT,
+        referenceId: adminId,
+        description: dto.reason,
+      };
+
+      const txn =
+        dto.direction === "credit"
+          ? await this.coinService.creditCoins(
+              targetUserId,
+              dto.amount,
+              metadata,
+              tx,
+            )
+          : await this.coinService.debitCoins(
+              targetUserId,
+              dto.amount,
+              metadata,
+              tx,
+            );
+
+      const updated = await tx.user.findUniqueOrThrow({
+        where: { id: targetUserId },
+      });
+
+      await this.auditRepo.create(tx, {
+        adminId,
+        action: "COIN_ADJUST",
+        targetUserId,
+        payload: {
+          amount: dto.amount,
+          direction: dto.direction,
+          reason: dto.reason,
+          balanceBefore,
+          balanceAfter: updated.coinBalance,
+        },
+      });
+
+      return { balance: updated.coinBalance, transactionId: txn.id };
+    });
+  }
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,6 +6,7 @@ import devRoutes from "./dev.routes";
 import coinRoutes from "./coin.routes";
 import paymentRoutes from "./payment.routes";
 import adminCoinPackageRoutes from "./admin.coin-package.routes";
+import adminUsersRoutes from "../modules/admin/routes/admin.users.routes";
 import adminHouseRoutes from "./admin.house.routes";
 import analyticsRoutes from "../modules/analytics/routes/analytics.routes";
 import authRoutes from "../modules/auth/routes/auth.routes";
@@ -26,6 +27,7 @@ router.use("/users", userRoutes);
 router.use("/coins", coinRoutes);
 router.use("/payments", paymentRoutes);
 router.use("/admin/coin-packages", adminCoinPackageRoutes);
+router.use("/admin/users", adminUsersRoutes);
 router.use("/admin/rewards/tickets", adminTicketRoutes);
 router.use("/admin/rewards", adminRewardRoutes);
 router.use("/admin/house", adminHouseRoutes);
@@ -54,6 +56,7 @@ router.get("/", (req, res) => {
       coins: "/api/v1/coins",
       payments: "/api/v1/payments",
       adminCoinPackages: "/api/v1/admin/coin-packages",
+      adminUsers: "/api/v1/admin/users",
       adminRewards: "/api/v1/admin/rewards",
       adminHouse: "/api/v1/admin/house",
       leaderboard: "/api/v1/leaderboard",

--- a/apps/web/src/components/admin/AdjustCoinsModal.tsx
+++ b/apps/web/src/components/admin/AdjustCoinsModal.tsx
@@ -1,0 +1,220 @@
+import React, { useEffect, useState } from "react";
+import type { AdjustCoinsRequest, UserPublic } from "@sarradabet/types";
+import { Input, Select } from "@sarradahub/design-system";
+import SportsbookModal, { sportsbookFieldClass } from "../ui/SportsbookModal";
+import { Button } from "../ui/Button";
+import { ErrorMessage } from "../ui/ErrorMessage";
+import { adminUserService } from "../../services/AdminUserService";
+import { getApiErrorMessage } from "../../utils/apiError";
+
+interface AdjustCoinsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  user: UserPublic | null;
+  onCoinsAdjusted: () => void;
+}
+
+type Direction = AdjustCoinsRequest["direction"];
+
+const emptyForm = {
+  direction: "credit" as Direction,
+  amount: "",
+  reason: "",
+};
+
+const AdjustCoinsModal: React.FC<AdjustCoinsModalProps> = ({
+  isOpen,
+  onClose,
+  user,
+  onCoinsAdjusted,
+}) => {
+  const [formData, setFormData] = useState(emptyForm);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [confirmDebit, setConfirmDebit] = useState(false);
+
+  useEffect(() => {
+    if (isOpen && user) {
+      setFormData(emptyForm);
+      setValidationErrors([]);
+      setSubmitError(null);
+      setConfirmDebit(false);
+    }
+  }, [isOpen, user]);
+
+  const validateForm = (): boolean => {
+    const errors: string[] = [];
+    const amount = Number.parseInt(formData.amount, 10);
+    const reason = formData.reason.trim();
+
+    if (!formData.amount || Number.isNaN(amount) || amount <= 0) {
+      errors.push("Informe um valor positivo");
+    }
+    if (reason.length < 3) {
+      errors.push("Motivo deve ter pelo menos 3 caracteres");
+    }
+    if (
+      formData.direction === "debit" &&
+      user &&
+      !Number.isNaN(amount) &&
+      amount > user.coinBalance
+    ) {
+      errors.push("Valor excede o saldo disponível");
+    }
+
+    setValidationErrors(errors);
+    return errors.length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!user || !validateForm()) {
+      return;
+    }
+
+    if (formData.direction === "debit" && !confirmDebit) {
+      setConfirmDebit(true);
+      return;
+    }
+
+    setSaving(true);
+    setSubmitError(null);
+
+    try {
+      await adminUserService.adjustCoins(user.id, {
+        amount: Number.parseInt(formData.amount, 10),
+        direction: formData.direction,
+        reason: formData.reason.trim(),
+      });
+      onCoinsAdjusted();
+      onClose();
+    } catch (error) {
+      setSubmitError(
+        getApiErrorMessage(error, "Não foi possível ajustar as moedas."),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  const directionLabel =
+    formData.direction === "credit" ? "Creditar" : "Debitar";
+  const directionColor =
+    formData.direction === "credit"
+      ? "text-emerald-400"
+      : "text-red-400";
+
+  return (
+    <SportsbookModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Ajustar moedas"
+      description={user.username}
+      size="md"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <p className="text-sm text-sportsbook-muted">
+          Saldo atual:{" "}
+          <span className="font-semibold text-sportsbook-fg">
+            {user.coinBalance} moedas
+          </span>
+        </p>
+
+        <Select
+          id="adjust-coins-direction"
+          label="Operação"
+          value={formData.direction}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+            setConfirmDebit(false);
+            setFormData((current) => ({
+              ...current,
+              direction: event.target.value as Direction,
+            }));
+          }}
+          options={[
+            { value: "credit", label: "Creditar" },
+            { value: "debit", label: "Debitar" },
+          ]}
+          className={sportsbookFieldClass}
+        />
+
+        <Input
+          id="adjust-coins-amount"
+          type="number"
+          label="Quantidade"
+          min={1}
+          value={formData.amount}
+          onChange={(event) =>
+            setFormData((current) => ({
+              ...current,
+              amount: event.target.value,
+            }))
+          }
+          className={sportsbookFieldClass}
+        />
+
+        <div>
+          <label
+            htmlFor="adjust-coins-reason"
+            className="block text-sm font-medium text-sportsbook-fg mb-1.5"
+          >
+            Motivo
+          </label>
+          <textarea
+            id="adjust-coins-reason"
+            value={formData.reason}
+            onChange={(event) =>
+              setFormData((current) => ({
+                ...current,
+                reason: event.target.value,
+              }))
+            }
+            placeholder="Motivo do ajuste"
+            rows={3}
+            className={`${sportsbookFieldClass} w-full rounded-lg px-3 py-2 text-sm resize-y`}
+          />
+        </div>
+
+        {confirmDebit && formData.direction === "debit" && (
+          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            Confirmar débito de {formData.amount} moedas de {user.username}?
+          </div>
+        )}
+
+        {validationErrors.length > 0 && (
+          <ErrorMessage error={validationErrors} title="Erros de validação" />
+        )}
+        {submitError && <ErrorMessage error={submitError} title="Erro" />}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            loading={saving}
+            disabled={saving}
+            variant={formData.direction === "debit" ? "danger" : "primary"}
+          >
+            {confirmDebit && formData.direction === "debit"
+              ? "Confirmar débito"
+              : `${directionLabel} moedas`}
+          </Button>
+        </div>
+
+        <p className={`text-xs ${directionColor}`}>
+          {formData.direction === "credit"
+            ? "Crédito adiciona moedas ao saldo do usuário."
+            : "Débito remove moedas do saldo do usuário."}
+        </p>
+      </form>
+    </SportsbookModal>
+  );
+};
+
+export default AdjustCoinsModal;

--- a/apps/web/src/components/admin/__tests__/AdjustCoinsModal.test.tsx
+++ b/apps/web/src/components/admin/__tests__/AdjustCoinsModal.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { UserPublic } from "@sarradabet/types";
+import AdjustCoinsModal from "../AdjustCoinsModal";
+
+vi.mock("../../services/AdminUserService", () => ({
+  adminUserService: {
+    adjustCoins: vi.fn(),
+  },
+}));
+
+const mockUser: UserPublic = {
+  id: 1,
+  username: "testuser",
+  email: "test@example.com",
+  phone: "5511999999999",
+  role: "USER",
+  coinBalance: 100,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("AdjustCoinsModal", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    user: mockUser,
+    onCoinsAdjusted: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows current balance", () => {
+    render(<AdjustCoinsModal {...defaultProps} />);
+
+    expect(screen.getByText(/100 moedas/)).toBeInTheDocument();
+  });
+
+  it("shows validation errors for invalid amount and reason", () => {
+    render(<AdjustCoinsModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/Quantidade/i), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText(/Motivo/i), {
+      target: { value: "ab" },
+    });
+
+    const form = screen
+      .getByRole("button", { name: /Creditar moedas/i })
+      .closest("form");
+    fireEvent.submit(form!);
+
+    expect(screen.getByText("Informe um valor positivo")).toBeInTheDocument();
+    expect(
+      screen.getByText("Motivo deve ter pelo menos 3 caracteres"),
+    ).toBeInTheDocument();
+  });
+
+  it("requires debit confirmation before submit", () => {
+    render(<AdjustCoinsModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText(/Operação/i), {
+      target: { value: "debit" },
+    });
+    fireEvent.change(screen.getByLabelText(/Quantidade/i), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByLabelText(/Motivo/i), {
+      target: { value: "Ajuste manual" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Debitar moedas/i }));
+
+    expect(
+      screen.getByText(/Confirmar débito de 10 moedas/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Confirmar débito/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/AdminUsersPage.tsx
+++ b/apps/web/src/pages/AdminUsersPage.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { Pencil } from "lucide-react";
+import { Coins, Pencil } from "lucide-react";
 import type { UserPublic } from "@sarradabet/types";
 import { Button } from "../components/ui/Button";
+import AdjustCoinsModal from "../components/admin/AdjustCoinsModal";
 import EditUserModal from "../components/admin/EditUserModal";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
@@ -21,6 +22,7 @@ const AdminUsersPage: React.FC = () => {
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [confirmUser, setConfirmUser] = useState<UserPublic | null>(null);
   const [editingUser, setEditingUser] = useState<UserPublic | null>(null);
+  const [adjustingUser, setAdjustingUser] = useState<UserPublic | null>(null);
 
   const loadUsers = async () => {
     try {
@@ -70,6 +72,16 @@ const AdminUsersPage: React.FC = () => {
         }}
       />
 
+      <AdjustCoinsModal
+        isOpen={Boolean(adjustingUser)}
+        onClose={() => setAdjustingUser(null)}
+        user={adjustingUser}
+        onCoinsAdjusted={() => {
+          setAdjustingUser(null);
+          void loadUsers();
+        }}
+      />
+
       <div>
         <h1 className="font-display text-2xl font-bold text-sportsbook-fg">Usuários</h1>
         <p className="text-sportsbook-muted text-sm">
@@ -106,6 +118,15 @@ const AdminUsersPage: React.FC = () => {
                   <td className="px-4 py-3">{formatDate(user.createdAt)}</td>
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setAdjustingUser(user)}
+                        className="p-1.5 rounded text-sportsbook-muted hover:text-emerald-400 hover:bg-sportsbook-raised transition-colors"
+                        aria-label={`Ajustar moedas de ${user.username}`}
+                        title="Ajustar moedas"
+                      >
+                        <Coins className="w-4 h-4" />
+                      </button>
                       <button
                         type="button"
                         onClick={() => setEditingUser(user)}

--- a/apps/web/src/services/AdminUserService.ts
+++ b/apps/web/src/services/AdminUserService.ts
@@ -1,0 +1,20 @@
+import type { AdjustCoinsRequest, AdjustCoinsResponse } from "@sarradabet/types";
+import type { ApiResponse } from "../core/interfaces/IService";
+import { createApiClient } from "./apiClient";
+
+class AdminUserService {
+  private readonly api = createApiClient("admin/users");
+
+  async adjustCoins(
+    userId: number,
+    data: AdjustCoinsRequest,
+  ): Promise<AdjustCoinsResponse> {
+    const response = await this.api.post<ApiResponse<AdjustCoinsResponse>>(
+      `/${userId}/coins/adjust`,
+      data,
+    );
+    return response.data.data;
+  }
+}
+
+export const adminUserService = new AdminUserService();

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,6 +114,7 @@ Require `Authorization: Bearer <accessToken>`:
 | `POST /api/v1/rewards/:id/redeem` | Any authenticated user |
 | `GET /api/v1/rewards/tickets/:uuid/image` | Ticket owner |
 | `GET/POST/PUT/DELETE /api/v1/admin/coin-packages` | Admin only |
+| `POST /api/v1/admin/users/:id/coins/adjust` | Admin only |
 | `GET/POST/PUT/DELETE /api/v1/admin/rewards` | Admin only |
 | `POST /api/v1/admin/rewards/tickets/:code/validate` | Admin only |
 | `GET /api/v1/admin/analytics/*` | Admin only |
@@ -1103,6 +1104,51 @@ Partial update — same fields as create, all optional.
 **DELETE** `/admin/coin-packages/:id`
 
 Soft-deactivates the package (`isActive: false`). Does not delete historical payments.
+
+## Admin User Coin Adjustment
+
+### Adjust User Coins
+
+**POST** `/admin/users/:id/coins/adjust`
+
+Credits or debits a user's coin balance atomically. Creates a `CoinTransaction` with source `ADMIN_ADJUSTMENT` and an `AdminAuditLog` entry.
+
+**Auth:** Admin only.
+
+**Request:**
+
+```json
+{
+  "amount": 100,
+  "direction": "credit",
+  "reason": "Promotional bonus"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | integer | Yes | Positive coin amount |
+| `direction` | `"credit"` \| `"debit"` | Yes | Add or remove coins |
+| `reason` | string | Yes | Audit reason (min 3 chars) |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "balance": 150,
+    "transactionId": 42
+  }
+}
+```
+
+**Errors:**
+
+- `400` — Invalid amount, insufficient balance on debit, or validation failure
+- `401` — Unauthenticated
+- `403` — Non-admin
+- `404` — Target user not found
 
 ## Leaderboard and User Stats
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Detailed spec: [features/06-mobile-app-and-admin-panel.md](./features/06-mobile-
 | Push notifications (Expo) | Planned |
 | Admin user list with search | Planned |
 | Admin ban/unban | Planned |
-| Admin manual coin adjust (`ADMIN_ADJUSTMENT`) | Planned |
+| Admin manual coin adjust (`ADMIN_ADJUSTMENT`) | Shipped |
 | Admin Pix payment monitor UI | Planned |
 
 **Already shipped (not on this list):** web admin for bets, categories, coin packages, rewards CRUD, analytics dashboards, basic user management pages.
@@ -27,7 +27,6 @@ Executable agent/developer plans. All **Planned**.
 | # | Initiative | Guide |
 |---|------------|-------|
 | 01 | Social login (Google + Facebook OAuth) | [action-plans/01-social-login.md](./action-plans/01-social-login.md) |
-| 03 | Admin coin management (audit trail) | [action-plans/03-admin-coin-management.md](./action-plans/03-admin-coin-management.md) |
 | 04 | Financial disclaimers (PT/EN) | [action-plans/04-disclaimers.md](./action-plans/04-disclaimers.md) |
 | 05 | UX flow, breadcrumbs, 404 page | [action-plans/05-ux-flow-breadcrumbs.md](./action-plans/05-ux-flow-breadcrumbs.md) |
 | 06 | Supabase Storage reward image upload | [action-plans/06-supabase-upload.md](./action-plans/06-supabase-upload.md) |

--- a/docs/action-plans/README.md
+++ b/docs/action-plans/README.md
@@ -6,7 +6,7 @@ Step-by-step, MCP-aware implementation guides for Cursor agents and developers. 
 |---|------|--------|-------|
 | 01 | Social login | Planned | [01-social-login.md](./01-social-login.md) |
 | 02 | Dark mode toggle | Shipped | [02-dark-mode-toggle.md](./02-dark-mode-toggle.md) |
-| 03 | Admin coin management | Planned | [03-admin-coin-management.md](./03-admin-coin-management.md) |
+| 03 | Admin coin management | Shipped | [03-admin-coin-management.md](./03-admin-coin-management.md) |
 | 04 | Financial disclaimers | Planned | [04-disclaimers.md](./04-disclaimers.md) |
 | 05 | UX flow & breadcrumbs | Planned | [05-ux-flow-breadcrumbs.md](./05-ux-flow-breadcrumbs.md) |
 | 06 | Supabase image upload | Planned | [06-supabase-upload.md](./06-supabase-upload.md) |

--- a/docs/features/06-mobile-app-and-admin-panel.md
+++ b/docs/features/06-mobile-app-and-admin-panel.md
@@ -25,7 +25,7 @@ Build a React Native + Expo mobile app in the monorepo, sharing types and API cl
 | Categories | [`AdminCategoriesPage.tsx`](../../apps/web/src/pages/AdminCategoriesPage.tsx) | Done — CRUD |
 | Coin packages | [`AdminCoinPackagesPage.tsx`](../../apps/web/src/pages/AdminCoinPackagesPage.tsx) | Done — CRUD |
 | Rewards | [`AdminRewardsPage.tsx`](../../apps/web/src/pages/AdminRewardsPage.tsx) | Done — CRUD |
-| Users | [`AdminUsersPage.tsx`](../../apps/web/src/pages/AdminUsersPage.tsx) | Partial — list only (no ban/coin adjust) |
+| Users | [`AdminUsersPage.tsx`](../../apps/web/src/pages/AdminUsersPage.tsx) | Partial — list + coin adjust (no ban) |
 | Admin layout + auth | [`AdminLayout.tsx`](../../apps/web/src/components/admin/AdminLayout.tsx), [`useAdminAuth.ts`](../../apps/web/src/hooks/useAdminAuth.ts) | Done |
 
 ### Missing admin capabilities
@@ -511,7 +511,7 @@ Funcionalidade: Aplicativo Mobile e Painel Administrativo Avançado
 
 ### Advanced admin (web)
 
-- [ ] Admin users page: list, search, ban, coin adjust
+- [ ] Admin users page: list, search, ban
 - [ ] Admin Pix monitor: filter by status, view details
 - [x] Admin rewards CRUD — shipped
 - [x] Analytics dashboards — shipped
@@ -521,7 +521,7 @@ Funcionalidade: Aplicativo Mobile e Painel Administrativo Avançado
 
 - [ ] Ban middleware on auth routes
 - [ ] Admin user management endpoints
-- [ ] Admin coin adjustment via `CoinService` + audit log
+- [x] Admin coin adjustment via `CoinService` + audit log
 - [ ] Push token registration endpoint
 - [ ] Notification service triggered from payment/payout events
 

--- a/packages/types/src/coin.ts
+++ b/packages/types/src/coin.ts
@@ -58,3 +58,14 @@ export interface UpdateCoinPackageDto {
   isActive?: boolean;
   sortOrder?: number;
 }
+
+export interface AdjustCoinsRequest {
+  amount: number;
+  direction: "credit" | "debit";
+  reason: string;
+}
+
+export interface AdjustCoinsResponse {
+  balance: number;
+  transactionId: number;
+}


### PR DESCRIPTION
## Description

Adds admin-only manual coin adjustment for user accounts. Admins can credit or debit coins from **Admin → Usuários** with a required reason; each change is recorded as a `CoinTransaction` (`ADMIN_ADJUSTMENT`) and an `AdminAuditLog` row inside a single atomic transaction.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

Fixes Action Plan 03 — Admin Coin Management

## Changes Made

- [x] Add `AdminAuditLog` Prisma model + migration (`20260813220000_add_admin_audit_log`)
- [x] Add `POST /api/v1/admin/users/:id/coins/adjust` (admin-only, Zod validation, atomic credit/debit via `CoinService`)
- [x] Add `AdjustCoinsRequest` / `AdjustCoinsResponse` to `@sarradabet/types`
- [x] Add `AdjustCoinsModal` on `AdminUsersPage` (credit/debit, reason, debit confirmation)
- [x] Add API integration tests and web RTL tests for the modal
- [x] Update `docs/API.md`, `ROADMAP.md`, `AGENTS.md`, Feature 06, and action-plans README

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (`admin.coins.adjust.test.ts` — 401, 403, credit + audit, debit over balance)
- [ ] Manual testing completed
- [x] New tests added for new functionality (`admin.coins.adjust.test.ts`, `AdjustCoinsModal.test.tsx`)

**Commands run:**
```bash
npm run lint
npm run check-types
npx jest apps/api/src/__tests__/integration/admin.coins.adjust.test.ts
npm run test -- src/components/admin/__tests__/AdjustCoinsModal.test.tsx
```

## Screenshots (if applicable)

_Add screenshot of Admin → Usuários with the coins adjust modal open (credit and debit states)._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Reuses existing `CoinService.creditCoins` / `debitCoins` with a Prisma transaction client — no duplicated balance logic.
- Debit beyond available balance returns `400` (`Saldo insuficiente`); no partial update or audit row is written.
- `referenceId` on the coin transaction stores the admin user ID; `description` stores the adjustment reason.
- **Migration:** if local dev DB has drift from a ghost `add_oauth_accounts` migration, run `npx prisma migrate reset` in `apps/api` before applying this migration, or follow the drift cleanup steps in the PR discussion.