### PR TITLE
feat(web): add breadcrumbs, 404 page, and navigation UX fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ npm run dev              # api + web via Turbo
 | Mercado Pago QR instore | Shipped | Instore orders, webhook, Coins page tab |
 | Mobile & advanced admin | **Planned** | See [Feature 06](docs/features/06-mobile-app-and-admin-panel.md) |
 
-**Planned initiatives:** [docs/ROADMAP.md](docs/ROADMAP.md) and [docs/action-plans/](docs/action-plans/) (social login, disclaimers, breadcrumbs, Supabase upload).
+**Planned initiatives:** [docs/ROADMAP.md](docs/ROADMAP.md) and [docs/action-plans/](docs/action-plans/) (social login, Supabase upload).
 
 ---
 
@@ -287,6 +287,7 @@ Shipped behavior lives in living docs — not in deleted feature guides 01–05/
 
 | Date | Change |
 |------|--------|
+| 2026-08-16 | Shipped UX breadcrumbs, catch-all 404, nav dead-end fixes (login logos, ticket verify back link) |
 | 2026-08-13 | Shipped financial disclaimers (PT/EN banner + footer, Coins acknowledge gate) |
 | 2026-08-13 | Shipped admin coin adjust API + UI (`ADMIN_ADJUSTMENT`, `AdminAuditLog`) |
 | 2026-08-13 | Shipped dark/light mode toggle (ThemeProvider, ThemeToggle, dual CSS palette) |

--- a/apps/api/prisma/seed-simple.ts
+++ b/apps/api/prisma/seed-simple.ts
@@ -232,6 +232,7 @@ async function main() {
   await prisma.coinPackage.deleteMany();
   await prisma.refreshToken.deleteMany();
   await prisma.userAction.deleteMany();
+  await prisma.adminAuditLog.deleteMany();
   await prisma.user.deleteMany();
 
   console.log("📂 Creating category...");

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -272,6 +272,7 @@ async function main() {
   await prisma.coinPackage.deleteMany();
   await prisma.refreshToken.deleteMany();
   await prisma.userAction.deleteMany();
+  await prisma.adminAuditLog.deleteMany();
   await prisma.user.deleteMany();
 
   console.log("👤 Creating users...");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import CoinsPage from "./pages/CoinsPage";
 import LeaderboardPage from "./pages/LeaderboardPage";
 import RewardsPage from "./pages/RewardsPage";
 import TicketVerifyPage from "./pages/TicketVerifyPage";
+import NotFoundPage from "./pages/NotFoundPage";
 import { AuthProvider } from "./context/AuthProvider";
 import { RealtimeProvider } from "./context/RealtimeProvider";
 import { ThemeProvider } from "./context/ThemeProvider";
@@ -141,7 +142,9 @@ function App() {
                     </Suspense>
                   }
                 />
+                <Route path="*" element={<NotFoundPage />} />
               </Route>
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </main>
         </RealtimeProvider>

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ import {
   DesktopNav,
   HamburgerButton,
   MobileDrawer,
+  Breadcrumb,
 } from "./navigation";
 
 interface NavigationProps {
@@ -22,38 +23,41 @@ const Navigation = ({ mobileCategoryTrigger }: NavigationProps) => {
   };
 
   return (
-    <header
-      className={`sticky top-0 sb-surface border-b sb-border shrink-0 ${
-        isOpen ? "z-[70]" : "z-50"
-      }`}
-    >
-      <div className="flex items-center justify-between h-12 px-4 gap-3">
-        <div className="flex items-center gap-3 min-w-0">
-          {mobileCategoryTrigger}
-          <BrandLogo size="sm" linkToHome />
+    <>
+      <header
+        className={`sticky top-0 sb-surface border-b sb-border shrink-0 ${
+          isOpen ? "z-[70]" : "z-50"
+        }`}
+      >
+        <div className="flex items-center justify-between h-12 px-4 gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            {mobileCategoryTrigger}
+            <BrandLogo size="sm" linkToHome />
+          </div>
+
+          <DesktopNav
+            isAuthenticated={isAuthenticated}
+            isAdmin={isAdmin}
+            onLogout={handleLogout}
+          />
+
+          <div className="flex items-center gap-1 lg:hidden">
+            <ThemeToggle />
+            <HamburgerButton isOpen={isOpen} onToggle={toggle} />
+          </div>
         </div>
 
-        <DesktopNav
+        <MobileDrawer
+          isOpen={isOpen}
+          onClose={close}
+          prefersReducedMotion={prefersReducedMotion}
           isAuthenticated={isAuthenticated}
           isAdmin={isAdmin}
           onLogout={handleLogout}
         />
-
-        <div className="flex items-center gap-1 lg:hidden">
-          <ThemeToggle />
-          <HamburgerButton isOpen={isOpen} onToggle={toggle} />
-        </div>
-      </div>
-
-      <MobileDrawer
-        isOpen={isOpen}
-        onClose={close}
-        prefersReducedMotion={prefersReducedMotion}
-        isAuthenticated={isAuthenticated}
-        isAdmin={isAdmin}
-        onLogout={handleLogout}
-      />
-    </header>
+      </header>
+      <Breadcrumb />
+    </>
   );
 };
 

--- a/apps/web/src/components/admin/AdminLayout.tsx
+++ b/apps/web/src/components/admin/AdminLayout.tsx
@@ -7,6 +7,7 @@ import ThemeToggle from "../ThemeToggle";
 import { ErrorMessage } from "../ui/ErrorMessage";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
 import { useAdminAuth } from "../../hooks/useAdminAuth";
+import { Breadcrumb } from "../navigation/Breadcrumb";
 import { cn } from "../../utils/cn";
 
 const navItems = [
@@ -87,6 +88,10 @@ const AdminLayout: React.FC = () => {
           </div>
         </div>
       </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Breadcrumb />
+      </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <nav

--- a/apps/web/src/components/navigation/Breadcrumb.tsx
+++ b/apps/web/src/components/navigation/Breadcrumb.tsx
@@ -1,0 +1,120 @@
+import { Link, useLocation } from "react-router";
+import { buildBreadcrumbs } from "./buildBreadcrumbs";
+import { cn } from "../../utils/cn";
+
+function BreadcrumbListItem({
+  label,
+  href,
+  isCurrent,
+}: {
+  label: string;
+  href?: string;
+  isCurrent: boolean;
+}) {
+  return (
+    <li className="inline-flex items-center">
+      {href && !isCurrent ? (
+        <Link
+          to={href}
+          className="text-sportsbook-muted hover:text-sportsbook-fg transition-colors"
+        >
+          {label}
+        </Link>
+      ) : (
+        <span
+          aria-current={isCurrent ? "page" : undefined}
+          className={cn(
+            isCurrent && "font-semibold text-sportsbook-fg",
+            !isCurrent && "text-sportsbook-muted",
+          )}
+        >
+          {label}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function Separator() {
+  return (
+    <span aria-hidden="true" className="mx-1.5 text-sportsbook-muted">
+      ›
+    </span>
+  );
+}
+
+export function Breadcrumb() {
+  const { pathname } = useLocation();
+
+  if (pathname === "/") {
+    return null;
+  }
+
+  const items = buildBreadcrumbs(pathname);
+  const showEllipsis = items.length > 3;
+  const first = items[0];
+  const last = items[items.length - 1];
+  const middle = showEllipsis ? items.slice(1, -1) : items.slice(1, -1);
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="border-b sb-border sb-surface px-4 py-2"
+    >
+      <ol className="flex flex-wrap items-center text-sm list-none m-0 p-0">
+        {first && (
+          <>
+            <BreadcrumbListItem
+              label={first.label}
+              href={first.href}
+              isCurrent={items.length === 1}
+            />
+            {items.length > 1 && <Separator />}
+          </>
+        )}
+
+        {showEllipsis ? (
+          <>
+            <li className="inline-flex items-center sm:hidden">
+              <span className="text-sportsbook-muted" aria-hidden="true">
+                …
+              </span>
+            </li>
+            <li className="hidden sm:contents">
+              {middle.map((item, index) => (
+                <span key={`${item.label}-${index}`} className="contents">
+                  <BreadcrumbListItem
+                    label={item.label}
+                    href={item.href}
+                    isCurrent={false}
+                  />
+                  <Separator />
+                </span>
+              ))}
+            </li>
+            {showEllipsis && (
+              <span className="sm:hidden">
+                <Separator />
+              </span>
+            )}
+          </>
+        ) : (
+          middle.map((item, index) => (
+            <span key={`${item.label}-${index}`} className="contents">
+              <BreadcrumbListItem
+                label={item.label}
+                href={item.href}
+                isCurrent={false}
+              />
+              <Separator />
+            </span>
+          ))
+        )}
+
+        {last && items.length > 1 && (
+          <BreadcrumbListItem label={last.label} isCurrent />
+        )}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/src/components/navigation/__tests__/Breadcrumb.test.tsx
+++ b/apps/web/src/components/navigation/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import { Breadcrumb } from "../Breadcrumb";
+
+function renderBreadcrumb(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Breadcrumb />
+    </MemoryRouter>,
+  );
+}
+
+describe("Breadcrumb", () => {
+  it("renders nothing on home", () => {
+    const { container } = renderBreadcrumb("/");
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders "Início > Admin > Apostas" for /admin/bets', () => {
+    renderBreadcrumb("/admin/bets");
+
+    const nav = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Início" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(screen.getByRole("link", { name: "Admin" })).toHaveAttribute(
+      "href",
+      "/admin/dashboard",
+    );
+    expect(screen.getByText("Apostas")).toHaveAttribute("aria-current", "page");
+    expect(screen.queryByRole("link", { name: "Apostas" })).not.toBeInTheDocument();
+  });
+
+  it("renders last crumb without link on /coins", () => {
+    renderBreadcrumb("/coins");
+
+    expect(screen.getByRole("link", { name: "Início" })).toBeInTheDocument();
+    expect(screen.getByText("Moedas")).toHaveAttribute("aria-current", "page");
+    expect(screen.queryByRole("link", { name: "Moedas" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/navigation/__tests__/buildBreadcrumbs.test.ts
+++ b/apps/web/src/components/navigation/__tests__/buildBreadcrumbs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildBreadcrumbs } from "../buildBreadcrumbs";
+
+describe("buildBreadcrumbs", () => {
+  it('builds trail for "/admin/bets"', () => {
+    const items = buildBreadcrumbs("/admin/bets");
+
+    expect(items).toHaveLength(3);
+    expect(items[0]).toEqual({ label: "Início", href: "/" });
+    expect(items[1]).toEqual({ label: "Admin", href: "/admin/dashboard" });
+    expect(items[2]).toEqual({ label: "Apostas" });
+    expect(items[2].href).toBeUndefined();
+  });
+
+  it('builds trail for "/coins"', () => {
+    const items = buildBreadcrumbs("/coins");
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({ label: "Início", href: "/" });
+    expect(items[1]).toEqual({ label: "Moedas" });
+    expect(items[1].href).toBeUndefined();
+  });
+
+  it('builds trail for "/tickets/verify/ABC"', () => {
+    const items = buildBreadcrumbs("/tickets/verify/ABC");
+
+    expect(items).toHaveLength(4);
+    expect(items[0]).toEqual({ label: "Início", href: "/" });
+    expect(items[1]).toEqual({ label: "Ingressos", href: "/tickets" });
+    expect(items[2]).toEqual({ label: "Verificar", href: "/tickets/verify" });
+    expect(items[3]).toEqual({ label: "ABC" });
+    expect(items[3].href).toBeUndefined();
+  });
+
+  it('returns single "Início" for root path', () => {
+    const items = buildBreadcrumbs("/");
+
+    expect(items).toEqual([{ label: "Início" }]);
+  });
+});

--- a/apps/web/src/components/navigation/buildBreadcrumbs.ts
+++ b/apps/web/src/components/navigation/buildBreadcrumbs.ts
@@ -1,0 +1,34 @@
+import { ROUTE_LABELS } from "../../routes/routeLabels";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
+  const segments = pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return [{ label: "Início" }];
+  }
+
+  const items: BreadcrumbItem[] = [{ label: "Início", href: "/" }];
+  let path = "";
+
+  for (const segment of segments) {
+    path += `/${segment}`;
+    const label = ROUTE_LABELS[segment] ?? segment;
+    const isLast = path === pathname;
+
+    let href: string | undefined = isLast ? undefined : path;
+
+    if (segment === "admin" && !isLast) {
+      href = "/admin/dashboard";
+    }
+
+    items.push({ label, href });
+  }
+
+  items[items.length - 1].href = undefined;
+  return items;
+}

--- a/apps/web/src/components/navigation/index.ts
+++ b/apps/web/src/components/navigation/index.ts
@@ -1,6 +1,8 @@
+export { Breadcrumb } from "./Breadcrumb";
 export { default as DesktopNav } from "./DesktopNav";
 export { default as HamburgerButton } from "./HamburgerButton";
 export { default as MobileDrawer } from "./MobileDrawer";
 export { default as NavLinks } from "./NavLinks";
 export { default as UserSection } from "./UserSection";
+export * from "./buildBreadcrumbs";
 export * from "./navItems";

--- a/apps/web/src/pages/AdminLogin.tsx
+++ b/apps/web/src/pages/AdminLogin.tsx
@@ -68,7 +68,7 @@ const AdminLogin: React.FC = () => {
     <div className="min-h-screen bg-sportsbook-bg flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="flex flex-col items-center">
-          <BrandLogo size="lg" showText={false} />
+          <BrandLogo size="lg" showText={false} linkToHome />
           <h2 className="mt-4 text-center font-display text-3xl font-bold text-sportsbook-fg tracking-wide">
             Admin Login
           </h2>

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -47,7 +47,7 @@ const LoginPage: React.FC = () => {
     <div className="min-h-screen bg-sportsbook-bg flex items-center justify-center px-4">
       <div className="w-full max-w-md sb-surface border sb-border rounded-2xl p-6 space-y-6">
         <div className="flex flex-col items-center gap-3">
-          <BrandLogo size="md" />
+          <BrandLogo size="md" linkToHome />
           <h1 className="font-display text-2xl font-bold text-sportsbook-fg">
             Entrar
           </h1>

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,22 @@
+import { Link } from "react-router";
+import Navigation from "../components/Navigation";
+import { AppFooter } from "../components/legal/AppFooter";
+import { Button } from "../components/ui/Button";
+
+export default function NotFoundPage() {
+  return (
+    <div className="min-h-screen bg-sportsbook-bg text-sportsbook-fg flex flex-col">
+      <Navigation />
+      <div className="max-w-xl mx-auto px-4 py-16 space-y-6 flex-1 w-full text-center">
+        <h1 className="font-display text-3xl font-bold">Página não encontrada</h1>
+        <p className="text-sportsbook-muted">
+          A página que você procura não existe.
+        </p>
+        <Link to="/">
+          <Button variant="secondary">Voltar ao início</Button>
+        </Link>
+      </div>
+      <AppFooter />
+    </div>
+  );
+}

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -45,7 +45,7 @@ const RegisterPage: React.FC = () => {
     <div className="min-h-screen bg-sportsbook-bg flex items-center justify-center px-4">
       <div className="w-full max-w-md sb-surface border sb-border rounded-2xl p-6 space-y-6">
         <div className="flex flex-col items-center gap-3">
-          <BrandLogo size="md" />
+          <BrandLogo size="md" linkToHome />
           <h1 className="font-display text-2xl font-bold text-sportsbook-fg">
             Criar conta
           </h1>

--- a/apps/web/src/pages/TicketVerifyPage.tsx
+++ b/apps/web/src/pages/TicketVerifyPage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import type { TicketVerifyResponse } from "@sarradabet/types";
 import Navigation from "../components/Navigation";
 import { AppFooter } from "../components/legal/AppFooter";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
+import { Button } from "../components/ui/Button";
 import axios from "axios";
 import { ticketService } from "../services/ticketService";
 import { getApiErrorMessage } from "../utils/apiError";
@@ -63,11 +64,16 @@ const TicketVerifyPage: React.FC = () => {
     <div className="min-h-screen bg-sportsbook-bg text-sportsbook-fg flex flex-col">
       <Navigation />
       <div className="max-w-xl mx-auto px-4 py-8 space-y-6 flex-1 w-full">
-        <div>
-          <h1 className="font-display text-3xl font-bold">Verificação de ticket</h1>
-          <p className="text-sm text-sportsbook-muted mt-1">
-            Confira a autenticidade de um ticket SarradaBet
-          </p>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="font-display text-3xl font-bold">Verificação de ticket</h1>
+            <p className="text-sm text-sportsbook-muted mt-1">
+              Confira a autenticidade de um ticket SarradaBet
+            </p>
+          </div>
+          <Link to="/">
+            <Button variant="secondary">Voltar ao início</Button>
+          </Link>
         </div>
 
         {loading && <LoadingSpinner text="Verificando ticket..." />}

--- a/apps/web/src/pages/__tests__/NotFoundPage.test.tsx
+++ b/apps/web/src/pages/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import NotFoundPage from "../NotFoundPage";
+
+vi.mock("../../components/Navigation", () => ({
+  default: () => <nav data-testid="navigation" />,
+}));
+
+vi.mock("../../components/legal/AppFooter", () => ({
+  AppFooter: () => <footer data-testid="app-footer" />,
+}));
+
+describe("NotFoundPage", () => {
+  it("renders heading and home link", () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Página não encontrada" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("A página que você procura não existe."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Voltar ao início" }),
+    ).toHaveAttribute("href", "/");
+  });
+});

--- a/apps/web/src/routes/routeLabels.ts
+++ b/apps/web/src/routes/routeLabels.ts
@@ -1,0 +1,16 @@
+export const ROUTE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  dashboard: "Dashboard",
+  bets: "Apostas",
+  categories: "Categorias",
+  "coin-packages": "Pacotes de moedas",
+  users: "Usuários",
+  rewards: "Recompensas",
+  coins: "Moedas",
+  profile: "Perfil",
+  leaderboard: "Ranking",
+  login: "Entrar",
+  register: "Cadastrar",
+  tickets: "Ingressos",
+  verify: "Verificar",
+};

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@ Executable agent/developer plans. All **Planned**.
 |---|------------|-------|
 | 01 | Social login (Google + Facebook OAuth) | [action-plans/01-social-login.md](./action-plans/01-social-login.md) |
 | 04 | Financial disclaimers (PT/EN) | Shipped — [04-disclaimers.md](./action-plans/04-disclaimers.md) |
-| 05 | UX flow, breadcrumbs, 404 page | [action-plans/05-ux-flow-breadcrumbs.md](./action-plans/05-ux-flow-breadcrumbs.md) |
+| 05 | UX flow, breadcrumbs, 404 page | Shipped — [05-ux-flow-breadcrumbs.md](./action-plans/05-ux-flow-breadcrumbs.md) |
 | 06 | Supabase Storage reward image upload | [action-plans/06-supabase-upload.md](./action-plans/06-supabase-upload.md) |
 
 ## Documentation backlog

--- a/docs/action-plans/README.md
+++ b/docs/action-plans/README.md
@@ -8,7 +8,7 @@ Step-by-step, MCP-aware implementation guides for Cursor agents and developers. 
 | 02 | Dark mode toggle | Shipped | [02-dark-mode-toggle.md](./02-dark-mode-toggle.md) |
 | 03 | Admin coin management | Shipped | [03-admin-coin-management.md](./03-admin-coin-management.md) |
 | 04 | Financial disclaimers | Shipped | [04-disclaimers.md](./04-disclaimers.md) |
-| 05 | UX flow & breadcrumbs | Planned | [05-ux-flow-breadcrumbs.md](./05-ux-flow-breadcrumbs.md) |
+| 05 | UX flow & breadcrumbs | Shipped | [05-ux-flow-breadcrumbs.md](./05-ux-flow-breadcrumbs.md) |
 | 06 | Supabase image upload | Planned | [06-supabase-upload.md](./06-supabase-upload.md) |
 
 Each plan follows TDD, Clean Architecture patterns, and references the current codebase. Shipped behavior belongs in [API.md](../API.md) and [ARCHITECTURE.md](../ARCHITECTURE.md), not in these plans.

--- a/e2e/features/navegacao.feature
+++ b/e2e/features/navegacao.feature
@@ -34,3 +34,10 @@ Funcionalidade: Navegação e rotas protegidas
     Então devo ver a URL contendo "/admin/users"
     Quando clico em "Pacotes"
     Então devo ver a URL contendo "/admin/coin-packages"
+
+  @regression
+  Cenário: Rota inexistente exibe página 404
+    Dado que não estou autenticado
+    Quando navego para "/pagina-inexistente"
+    Então devo ver o texto "Página não encontrada"
+    E devo ver o link "Voltar ao início"


### PR DESCRIPTION
## Description

Implements [Action Plan 05](docs/action-plans/05-ux-flow-breadcrumbs.md): improves SPA navigation UX with accessible breadcrumbs, a catch-all 404 page, and fixes for navigation dead ends. Also fixes database seeding when `admin_audit_logs` rows exist.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

N/A — internal UX improvement (Action Plan 05)

## Changes Made

- [x] Add `buildBreadcrumbs()` pure function and `ROUTE_LABELS` config for path → segment mapping
- [x] Add accessible `<Breadcrumb />` component (hidden on `/`, mobile ellipsis for long trails) in `Navigation` and `AdminLayout`
- [x] Add `NotFoundPage` with catch-all routes at root and inside `/admin/*`
- [x] Fix nav dead ends: `linkToHome` on login/register/admin login logos; "Voltar ao início" on ticket verify page
- [x] Fix seed scripts: delete `adminAuditLog` before `user` to avoid FK constraint violations
- [x] Add unit/RTL tests for breadcrumbs and 404; E2E scenario for unknown routes
- [x] Mark Action Plan 05 as Shipped in `ROADMAP.md`, `action-plans/README.md`, and `AGENTS.md`

## Testing

- [x] Unit tests pass (`npm run test:web` — 129 tests)
- [ ] Integration tests pass
- [x] Manual testing completed (route audit: 404, breadcrumbs on admin/public pages, auth logo links)
- [x] New tests added for new functionality

## Screenshots (if applicable)

_Add screenshots of breadcrumbs on `/admin/bets`, `/coins`, and the 404 page if helpful._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Breadcrumbs are mounted in `Navigation` (public pages) and `AdminLayout` (admin panel) — no per-page wiring needed.
- Home (`/`) intentionally hides the breadcrumb trail.
- Admin breadcrumb "Admin" links to `/admin/dashboard`.
- Seed fix mirrors cleanup order in `authTestHelper.ts`.