### PR TITLE
feat(upload): add Supabase Storage reward image upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Cross-agent memory for [SarradaBet](https://github.com/SarradaHub/sarradabet): a mock betting platform with real-time parimutuel odds, authenticated stake voting, coin purchases via Mercado Pago Pix (online + instore QR), gamification, and shared TypeScript contracts.
 
 > **Purpose:** Primes Cursor Agent/Composer with repo context — what is **shipped**, what is **planned**, coding standards, and gotchas.  
-> **Last updated:** 2026-08-09  
+> **Last updated:** 2026-08-16  
 > **Maintainer:** Update when features ship or architecture changes.
 
 ---
@@ -49,6 +49,7 @@ Cross-agent memory for [SarradaBet](https://github.com/SarradaHub/sarradabet): a
 | `MERCADOPAGO_ACCESS_TOKEN` | Pix online + instore |
 | `MERCADOPAGO_WEBHOOK_SECRET` | Webhook HMAC validation |
 | `MERCADOPAGO_STORE_ID`, `MERCADOPAGO_POS_ID`, `MERCADOPAGO_POS_UUID` | Instore QR |
+| `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_STORAGE_BUCKET` | Reward image upload (API service role only) |
 | `BET_TAKEOUT_RATE`, `HOUSE_USER_USERNAME` | Parimutuel house takeout |
 | `MERCADOPAGO_MOCK_PIX` | Local Pix without real MP |
 
@@ -121,6 +122,7 @@ npm run dev              # api + web via Turbo
 | Gamification & rewards | Shipped | Leaderboard, stats, rewards redeem, ticket verify/PNG |
 | Dashboard & analytics | Shipped | User dashboard, admin analytics + CSV export |
 | Mercado Pago QR instore | Shipped | Instore orders, webhook, Coins page tab |
+| Reward image upload (Supabase Storage) | Shipped | `POST /admin/uploads/reward-image`, admin drag-drop UI |
 | Mobile & advanced admin | **Planned** | See [Feature 06](docs/features/06-mobile-app-and-admin-panel.md) |
 
 **Planned initiatives:** [docs/ROADMAP.md](docs/ROADMAP.md) and [docs/action-plans/](docs/action-plans/) (social login, Supabase upload).
@@ -142,6 +144,7 @@ Base: `http://localhost:8000/api/v1`. Full reference: [`docs/API.md`](docs/API.m
 | POST | `/rewards/:id/redeem` | Required | Generates ticket |
 | GET/POST | `/admin/rewards`, `/admin/analytics/*` | Admin | CRUD + analytics |
 | POST | `/admin/users/:id/coins/adjust` | Admin | Credit/debit + audit log |
+| POST | `/admin/uploads/reward-image` | Admin | Multipart reward image → Supabase Storage URL |
 | POST | `/webhooks/mercadopago` | MP HMAC | No JWT |
 
 **Not shipped (Planned — Feature 06):** `PATCH /admin/users/:id/ban`, `GET /admin/payments/pix`.
@@ -287,6 +290,7 @@ Shipped behavior lives in living docs — not in deleted feature guides 01–05/
 
 | Date | Change |
 |------|--------|
+| 2026-08-16 | Shipped Supabase Storage reward image upload (API upload route, admin drag-drop UI, bucket `reward-images`) |
 | 2026-08-16 | Shipped UX breadcrumbs, catch-all 404, nav dead-end fixes (login logos, ticket verify back link) |
 | 2026-08-13 | Shipped financial disclaimers (PT/EN banner + footer, Coins acknowledge gate) |
 | 2026-08-13 | Shipped admin coin adjust API + UI (`ADMIN_ADJUSTMENT`, `AdminAuditLog`) |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,6 +26,12 @@ PUBLIC_WEB_URL=http://localhost:3002
 TICKET_IMAGE_CACHE_TTL=3600
 TICKET_IMAGE_RATE_LIMIT_MAX=5
 
+# Supabase Storage (reward image uploads — server only)
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_STORAGE_BUCKET=reward-images
+UPLOAD_MAX_BYTES=2097152
+
 # Mercado Pago — online Pix (coin purchases)
 # Put real tokens in .env.local (gitignored); see docs/LOCAL_WEBHOOKS.md and docs/API.md
 MERCADOPAGO_ACCESS_TOKEN=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.9",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.19.1",
     "@types/opossum": "^8.1.9",
     "@types/qrcode": "^1.5.6",
@@ -62,6 +63,7 @@
   "dependencies": {
     "@prisma/client": "^6.19.1",
     "@sarradabet/types": "*",
+    "@supabase/supabase-js": "^2.112.3",
     "@types/express": "^5.0.0",
     "axios": "^1.18.0",
     "bcryptjs": "^3.0.3",
@@ -80,6 +82,7 @@
     "jsonwebtoken": "^9.0.3",
     "mercadopago": "^3.2.0",
     "morgan": "^1.10.0",
+    "multer": "^2.2.0",
     "node-cache": "^5.1.2",
     "opossum": "^7.0.0",
     "prisma": "^6.19.1",

--- a/apps/api/src/__tests__/integration/admin.upload.test.ts
+++ b/apps/api/src/__tests__/integration/admin.upload.test.ts
@@ -1,0 +1,175 @@
+const testDbUrl = (() => {
+  const url =
+    process.env.DATABASE_URL ||
+    "postgresql://appuser:sarradabet1234@localhost:5433/sarradabet_test";
+
+  if (url.includes("/sarradabet") && !url.includes("/sarradabet_test")) {
+    return url.replace("/sarradabet", "/sarradabet_test");
+  }
+
+  return url;
+})();
+
+process.env.DATABASE_URL = testDbUrl;
+process.env.JWT_SECRET = "test-secret";
+process.env.SUPABASE_URL = "https://example.supabase.co";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+
+jest.mock("../../modules/upload/services/StorageService", () => ({
+  StorageService: jest.fn().mockImplementation(() => ({
+    uploadRewardImage: jest.fn().mockResolvedValue(
+      "https://example.supabase.co/storage/v1/object/public/reward-images/rewards/test.webp",
+    ),
+  })),
+}));
+
+import { PrismaClient, UserRole } from "@prisma/client";
+import request from "supertest";
+import { app } from "../../app";
+import {
+  authHeader,
+  checkDatabaseConnection,
+  cleanupAuthData,
+  createTestUser,
+  testIfDbAvailable,
+  uniqueTestPhone,
+} from "../helpers/authTestHelper";
+
+let prisma: PrismaClient | null = null;
+let isDatabaseAvailable = false;
+
+describe("Admin Upload Routes", () => {
+  beforeAll(async () => {
+    isDatabaseAvailable = await checkDatabaseConnection(testDbUrl);
+    if (!isDatabaseAvailable) return;
+
+    prisma = new PrismaClient({
+      datasources: { db: { url: testDbUrl } },
+    });
+    await cleanupAuthData(prisma);
+  });
+
+  afterAll(async () => {
+    if (prisma) {
+      await prisma.$disconnect();
+      prisma = null;
+    }
+  });
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return 401 without authentication",
+    async () => {
+      await request(app)
+        .post("/api/v1/admin/uploads/reward-image")
+        .attach("file", Buffer.from("fake"), {
+          filename: "test.jpg",
+          contentType: "image/jpeg",
+        })
+        .expect(401);
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return 403 for non-admin users",
+    async () => {
+      if (!prisma) return;
+
+      const user = await createTestUser(prisma, {
+        username: "uploaduser",
+        email: "uploaduser@example.com",
+        phone: uniqueTestPhone(888802),
+        role: UserRole.USER,
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: user.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      await request(app)
+        .post("/api/v1/admin/uploads/reward-image")
+        .set(authHeader(token))
+        .attach("file", Buffer.from("fake"), {
+          filename: "test.jpg",
+          contentType: "image/jpeg",
+        })
+        .expect(403);
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return 400 for unsupported MIME type",
+    async () => {
+      if (!prisma) return;
+
+      const admin = await createTestUser(prisma, {
+        username: "uploadadmin",
+        email: "uploadadmin@example.com",
+        phone: uniqueTestPhone(888803),
+        role: UserRole.ADMIN,
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: admin.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      const response = await request(app)
+        .post("/api/v1/admin/uploads/reward-image")
+        .set(authHeader(token))
+        .attach("file", Buffer.from("%PDF-1.4"), {
+          filename: "document.pdf",
+          contentType: "application/pdf",
+        })
+        .expect(400);
+
+      expect(response.body.message).toMatch(/unsupported image type/i);
+    },
+  );
+
+  testIfDbAvailable(
+    () => isDatabaseAvailable,
+    "should return public URL for admin upload",
+    async () => {
+      if (!prisma) return;
+
+      const admin = await createTestUser(prisma, {
+        username: "uploadadmin2",
+        email: "uploadadmin2@example.com",
+        phone: uniqueTestPhone(888804),
+        role: UserRole.ADMIN,
+      });
+
+      const loginResponse = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: admin.username, password: "password123" })
+        .expect(200);
+
+      const token = loginResponse.body.data.accessToken.token as string;
+
+      const pngBuffer = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "base64",
+      );
+
+      const response = await request(app)
+        .post("/api/v1/admin/uploads/reward-image")
+        .set(authHeader(token))
+        .attach("file", pngBuffer, {
+          filename: "pixel.png",
+          contentType: "image/png",
+        })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.url).toContain("reward-images/rewards/");
+    },
+  );
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -133,6 +133,10 @@ const envSchema = z.object({
   PUBLIC_WEB_URL: z.string().url().optional(),
   TICKET_IMAGE_CACHE_TTL: z.coerce.number().int().positive().default(3600),
   TICKET_IMAGE_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(5),
+  SUPABASE_URL: z.string().url().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  SUPABASE_STORAGE_BUCKET: z.string().default("reward-images"),
+  UPLOAD_MAX_BYTES: z.coerce.number().int().positive().default(2097152),
 });
 
 const parsed = envSchema.parse(process.env);

--- a/apps/api/src/config/supabase.ts
+++ b/apps/api/src/config/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { config } from "./env";
+
+export function createSupabaseAdminClient(): SupabaseClient {
+  if (!config.SUPABASE_URL || !config.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error("Supabase storage is not configured");
+  }
+
+  return createClient(config.SUPABASE_URL, config.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export function isSupabaseStorageConfigured(): boolean {
+  return Boolean(config.SUPABASE_URL && config.SUPABASE_SERVICE_ROLE_KEY);
+}

--- a/apps/api/src/modules/upload/__tests__/validateImage.test.ts
+++ b/apps/api/src/modules/upload/__tests__/validateImage.test.ts
@@ -1,0 +1,29 @@
+import { BadRequestError } from "../../../core/errors/AppError";
+import { validateImageFile } from "../utils/validateImageFile";
+
+jest.mock("../../../config/env", () => ({
+  config: {
+    UPLOAD_MAX_BYTES: 2097152,
+  },
+}));
+
+describe("validateImageFile", () => {
+  it("accepts allowed image MIME types within size limit", () => {
+    expect(() => validateImageFile("image/jpeg", 1024)).not.toThrow();
+    expect(() => validateImageFile("image/png", 1024)).not.toThrow();
+    expect(() => validateImageFile("image/webp", 1024)).not.toThrow();
+  });
+
+  it("rejects unsupported MIME types", () => {
+    expect(() => validateImageFile("application/pdf", 1024)).toThrow(
+      BadRequestError,
+    );
+    expect(() => validateImageFile("text/plain", 512)).toThrow(BadRequestError);
+  });
+
+  it("rejects files larger than UPLOAD_MAX_BYTES", () => {
+    expect(() => validateImageFile("image/jpeg", 2097153)).toThrow(
+      BadRequestError,
+    );
+  });
+});

--- a/apps/api/src/modules/upload/controllers/UploadController.ts
+++ b/apps/api/src/modules/upload/controllers/UploadController.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from "express";
+import { BadRequestError } from "../../../core/errors/AppError";
+import { ApiResponse } from "../../../utils/api/response";
+import { StorageService } from "../services/StorageService";
+
+export class UploadController {
+  constructor(
+    private readonly storageService: StorageService = new StorageService(),
+  ) {}
+
+  uploadRewardImage = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      if (!req.file) {
+        throw new BadRequestError("No file uploaded");
+      }
+
+      const url = await this.storageService.uploadRewardImage(
+        req.file.buffer,
+        req.file.mimetype,
+      );
+
+      new ApiResponse(res).success({ url });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/apps/api/src/modules/upload/middleware/uploadMiddleware.ts
+++ b/apps/api/src/modules/upload/middleware/uploadMiddleware.ts
@@ -1,0 +1,39 @@
+import multer, { MulterError } from "multer";
+import { NextFunction, Request, Response } from "express";
+import { BadRequestError } from "../../../core/errors/AppError";
+import { config } from "../../../config/env";
+import { ALLOWED_MIME_TYPES } from "../utils/validateImageFile";
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: config.UPLOAD_MAX_BYTES },
+  fileFilter: (_req, file, callback) => {
+    if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      callback(new BadRequestError("Unsupported image type"));
+      return;
+    }
+
+    callback(null, true);
+  },
+});
+
+export const rewardImageUpload = upload.single("file");
+
+export function handleUploadErrors(
+  err: unknown,
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  if (err instanceof MulterError) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      next(new BadRequestError("File too large"));
+      return;
+    }
+
+    next(new BadRequestError(err.message));
+    return;
+  }
+
+  next(err);
+}

--- a/apps/api/src/modules/upload/routes/admin.upload.routes.ts
+++ b/apps/api/src/modules/upload/routes/admin.upload.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { UserRole } from "@prisma/client";
+import {
+  authenticateUser,
+  requireUserRole,
+} from "../../../core/middleware/AuthMiddleware";
+import { UploadController } from "../controllers/UploadController";
+import {
+  handleUploadErrors,
+  rewardImageUpload,
+} from "../middleware/uploadMiddleware";
+
+const uploadController = new UploadController();
+
+const router = Router();
+
+router.use(authenticateUser, requireUserRole(UserRole.ADMIN));
+
+router.post(
+  "/reward-image",
+  rewardImageUpload,
+  handleUploadErrors,
+  uploadController.uploadRewardImage,
+);
+
+export default router;

--- a/apps/api/src/modules/upload/services/StorageService.ts
+++ b/apps/api/src/modules/upload/services/StorageService.ts
@@ -1,0 +1,47 @@
+import crypto from "crypto";
+import sharp from "sharp";
+import {
+  InternalServerError,
+  ServiceUnavailableError,
+} from "../../../core/errors/AppError";
+import { config } from "../../../config/env";
+import {
+  createSupabaseAdminClient,
+  isSupabaseStorageConfigured,
+} from "../../../config/supabase";
+import { validateImageFile } from "../utils/validateImageFile";
+
+export class StorageService {
+  async uploadRewardImage(buffer: Buffer, mime: string): Promise<string> {
+    if (!isSupabaseStorageConfigured()) {
+      throw new ServiceUnavailableError("Image upload is not configured");
+    }
+
+    validateImageFile(mime, buffer.length);
+
+    const optimized = await sharp(buffer)
+      .resize(1920, 1920, { fit: "inside", withoutEnlargement: true })
+      .webp({ quality: 85 })
+      .toBuffer();
+
+    if (optimized.length > config.UPLOAD_MAX_BYTES) {
+      throw new InternalServerError("Upload failed");
+    }
+
+    const path = `rewards/${crypto.randomUUID()}.webp`;
+    const supabase = createSupabaseAdminClient();
+    const bucket = config.SUPABASE_STORAGE_BUCKET;
+
+    const { error } = await supabase.storage.from(bucket).upload(path, optimized, {
+      contentType: "image/webp",
+      upsert: false,
+    });
+
+    if (error) {
+      throw new InternalServerError("Upload failed", { message: error.message });
+    }
+
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+    return data.publicUrl;
+  }
+}

--- a/apps/api/src/modules/upload/utils/validateImageFile.ts
+++ b/apps/api/src/modules/upload/utils/validateImageFile.ts
@@ -1,0 +1,20 @@
+import { BadRequestError } from "../../../core/errors/AppError";
+import { config } from "../../../config/env";
+
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export function validateImageFile(mime: string, size: number): void {
+  if (!ALLOWED_MIME_TYPES.has(mime)) {
+    throw new BadRequestError("Unsupported image type");
+  }
+
+  if (size > config.UPLOAD_MAX_BYTES) {
+    throw new BadRequestError("File too large");
+  }
+}
+
+export { ALLOWED_MIME_TYPES };

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -14,6 +14,7 @@ import userRoutes from "../modules/user/routes/user.routes";
 import jobsRoutes from "./jobs.routes";
 import leaderboardRoutes from "./leaderboard.routes";
 import rewardRoutes, { adminRewardRoutes } from "./reward.routes";
+import adminUploadRoutes from "../modules/upload/routes/admin.upload.routes";
 import {
   adminTicketRoutes,
   rewardTicketRoutes,
@@ -30,6 +31,7 @@ router.use("/admin/coin-packages", adminCoinPackageRoutes);
 router.use("/admin/users", adminUsersRoutes);
 router.use("/admin/rewards/tickets", adminTicketRoutes);
 router.use("/admin/rewards", adminRewardRoutes);
+router.use("/admin/uploads", adminUploadRoutes);
 router.use("/admin/house", adminHouseRoutes);
 router.use("/admin/analytics", analyticsRoutes);
 router.use("/leaderboard", leaderboardRoutes);
@@ -58,6 +60,7 @@ router.get("/", (req, res) => {
       adminCoinPackages: "/api/v1/admin/coin-packages",
       adminUsers: "/api/v1/admin/users",
       adminRewards: "/api/v1/admin/rewards",
+      adminUploads: "/api/v1/admin/uploads",
       adminHouse: "/api/v1/admin/house",
       leaderboard: "/api/v1/leaderboard",
       rewards: "/api/v1/rewards",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@sarradabet/types": "*",
     "@sarradahub/design-system": "file:../../../platform/design-system",
     "axios": "^1.18.0",
+    "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "didyoumean": "^1.2.2",

--- a/apps/web/src/components/admin/EditRewardModal.tsx
+++ b/apps/web/src/components/admin/EditRewardModal.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/Button";
 import { ErrorMessage } from "../ui/ErrorMessage";
 import { adminRewardService } from "../../services/rewardService";
 import { getApiErrorMessage } from "../../utils/apiError";
+import { ImageUploadField } from "./ImageUploadField";
 
 interface EditRewardModalProps {
   isOpen: boolean;
@@ -155,11 +156,10 @@ export function EditRewardModal({
             onChange={(e) => setForm({ ...form, stock: e.target.value })}
             required
           />
-          <input
-            className={sportsbookFieldClass}
-            placeholder="URL da imagem (opcional)"
+          <ImageUploadField
             value={form.imageUrl}
-            onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
+            onChange={(imageUrl) => setForm({ ...form, imageUrl })}
+            disabled={saving}
           />
           <textarea
             className={`${sportsbookFieldClass} md:col-span-2 min-h-24`}

--- a/apps/web/src/components/admin/ImageUploadField.tsx
+++ b/apps/web/src/components/admin/ImageUploadField.tsx
@@ -1,0 +1,152 @@
+import React, { useId, useRef, useState } from "react";
+import imageCompression from "browser-image-compression";
+import { sportsbookFieldClass } from "../ui/SportsbookModal";
+import { uploadRewardImage } from "../../services/uploadService";
+import { getApiErrorMessage } from "../../utils/apiError";
+
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+interface ImageUploadFieldProps {
+  value: string;
+  onChange: (url: string) => void;
+  disabled?: boolean;
+}
+
+function isAcceptedImage(file: File): boolean {
+  return ACCEPTED_TYPES.includes(file.type);
+}
+
+export function ImageUploadField({
+  value,
+  onChange,
+  disabled = false,
+}: ImageUploadFieldProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showManualUrl, setShowManualUrl] = useState(false);
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file || disabled || uploading) {
+      return;
+    }
+
+    if (!isAcceptedImage(file)) {
+      setError("Formato não suportado. Use JPG, PNG ou WebP.");
+      return;
+    }
+
+    setError(null);
+    setUploading(true);
+
+    try {
+      const compressed = await imageCompression(file, {
+        maxSizeMB: 1.5,
+        maxWidthOrHeight: 1920,
+        useWebWorker: true,
+      });
+
+      if (compressed.size > 2 * 1024 * 1024) {
+        setError("Imagem muito grande. Máximo 2 MB.");
+        return;
+      }
+
+      const url = await uploadRewardImage(compressed);
+      onChange(url);
+      setShowManualUrl(false);
+    } catch (uploadError) {
+      setError(getApiErrorMessage(uploadError, "Falha no envio. Tente novamente."));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (disabled || uploading) {
+      return;
+    }
+
+    void handleFile(event.dataTransfer.files[0]);
+  };
+
+  return (
+    <div className="space-y-3 md:col-span-2">
+      <div
+        role="button"
+        tabIndex={disabled || uploading ? -1 : 0}
+        aria-disabled={disabled || uploading}
+        aria-labelledby={`${inputId}-label`}
+        onDrop={onDrop}
+        onDragOver={(event) => event.preventDefault()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        onClick={() => {
+          if (!disabled && !uploading) {
+            inputRef.current?.click();
+          }
+        }}
+        className={`rounded-xl border border-dashed sb-border bg-sportsbook-raised/40 p-4 text-center transition-colors ${
+          disabled || uploading
+            ? "cursor-not-allowed opacity-70"
+            : "cursor-pointer hover:border-sportsbook-accent/60"
+        }`}
+      >
+        {value ? (
+          <img
+            src={value}
+            alt="Pré-visualização da recompensa"
+            className="mx-auto mb-3 max-h-40 rounded-lg object-contain"
+          />
+        ) : null}
+
+        <p id={`${inputId}-label`} className="text-sm text-sportsbook-muted">
+          {uploading
+            ? "Enviando imagem..."
+            : "Arraste uma imagem ou clique para selecionar"}
+        </p>
+
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={ACCEPTED_TYPES.join(",")}
+          className="sr-only"
+          disabled={disabled || uploading}
+          onChange={(event) => {
+            void handleFile(event.target.files?.[0]);
+            event.target.value = "";
+          }}
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      <button
+        type="button"
+        className="text-xs text-sportsbook-muted underline underline-offset-2 hover:text-sportsbook-fg"
+        onClick={() => setShowManualUrl((current) => !current)}
+        disabled={disabled || uploading}
+      >
+        {showManualUrl ? "Ocultar URL manual" : "Usar URL manual"}
+      </button>
+
+      {showManualUrl && (
+        <input
+          className={sportsbookFieldClass}
+          placeholder="URL da imagem (opcional)"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled || uploading}
+        />
+      )}
+    </div>
+  );
+}
+
+export default ImageUploadField;

--- a/apps/web/src/components/admin/ImageUploadField.tsx
+++ b/apps/web/src/components/admin/ImageUploadField.tsx
@@ -3,6 +3,7 @@ import imageCompression from "browser-image-compression";
 import { sportsbookFieldClass } from "../ui/SportsbookModal";
 import { uploadRewardImage } from "../../services/uploadService";
 import { getApiErrorMessage } from "../../utils/apiError";
+import { getSafeImageUrl } from "../../utils/safeImageUrl";
 
 const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
@@ -26,6 +27,7 @@ export function ImageUploadField({
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showManualUrl, setShowManualUrl] = useState(false);
+  const previewUrl = getSafeImageUrl(value);
 
   const handleFile = async (file: File | undefined) => {
     if (!file || disabled || uploading) {
@@ -97,9 +99,9 @@ export function ImageUploadField({
             : "cursor-pointer hover:border-sportsbook-accent/60"
         }`}
       >
-        {value ? (
+        {previewUrl ? (
           <img
-            src={value}
+            src={previewUrl}
             alt="Pré-visualização da recompensa"
             className="mx-auto mb-3 max-h-40 rounded-lg object-contain"
           />

--- a/apps/web/src/components/admin/__tests__/ImageUploadField.test.tsx
+++ b/apps/web/src/components/admin/__tests__/ImageUploadField.test.tsx
@@ -60,4 +60,15 @@ describe("ImageUploadField", () => {
     expect(uploadRewardImage).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("does not render preview for unsafe image URLs", () => {
+    render(
+      <ImageUploadField
+        value="javascript:alert(1)"
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/admin/__tests__/ImageUploadField.test.tsx
+++ b/apps/web/src/components/admin/__tests__/ImageUploadField.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ImageUploadField } from "../ImageUploadField";
+
+vi.mock("browser-image-compression", () => ({
+  default: vi.fn(async (file: File) => file),
+}));
+
+vi.mock("../../../services/uploadService", () => ({
+  uploadRewardImage: vi.fn(),
+}));
+
+import imageCompression from "browser-image-compression";
+import { uploadRewardImage } from "../../../services/uploadService";
+
+describe("ImageUploadField", () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows preview after successful upload", async () => {
+    vi.mocked(uploadRewardImage).mockResolvedValue(
+      "https://example.supabase.co/storage/v1/object/public/reward-images/rewards/test.webp",
+    );
+
+    render(<ImageUploadField value="" onChange={onChange} />);
+
+    const file = new File(["image"], "reward.png", { type: "image/png" });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(imageCompression).toHaveBeenCalled();
+      expect(uploadRewardImage).toHaveBeenCalledWith(file);
+      expect(onChange).toHaveBeenCalledWith(
+        "https://example.supabase.co/storage/v1/object/public/reward-images/rewards/test.webp",
+      );
+    });
+  });
+
+  it("rejects non-image files", async () => {
+    render(<ImageUploadField value="" onChange={onChange} />);
+
+    const file = new File(["pdf"], "document.pdf", {
+      type: "application/pdf",
+    });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Formato não suportado. Use JPG, PNG ou WebP."),
+      ).toBeInTheDocument();
+    });
+
+    expect(uploadRewardImage).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/AdminRewardsPage.tsx
+++ b/apps/web/src/pages/AdminRewardsPage.tsx
@@ -9,6 +9,7 @@ import { adminRewardService } from "../services/rewardService";
 import { getApiErrorMessage } from "../utils/apiError";
 import { TicketValidationModal } from "../components/admin/TicketValidationModal";
 import { EditRewardModal } from "../components/admin/EditRewardModal";
+import { ImageUploadField } from "../components/admin/ImageUploadField";
 
 const emptyForm = {
   title: "",
@@ -158,11 +159,10 @@ const AdminRewardsPage: React.FC = () => {
             onChange={(e) => setForm({ ...form, stock: e.target.value })}
             required
           />
-          <input
-            className={sportsbookFieldClass}
-            placeholder="URL da imagem (opcional)"
+          <ImageUploadField
             value={form.imageUrl}
-            onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
+            onChange={(imageUrl) => setForm({ ...form, imageUrl })}
+            disabled={saving}
           />
           <textarea
             className={`${sportsbookFieldClass} md:col-span-2 min-h-24`}

--- a/apps/web/src/services/apiClient.ts
+++ b/apps/web/src/services/apiClient.ts
@@ -181,6 +181,30 @@ export function createApiClient(endpoint: string): AxiosInstance {
   return client;
 }
 
+export async function uploadMultipart(
+  endpoint: string,
+  formData: FormData,
+  timeoutMs = 30000,
+): Promise<unknown> {
+  const token = authHandlers.getAccessToken();
+  const csrf = csrfToken ?? (await fetchCsrfToken());
+
+  const response = await axios.post(
+    `${getApiRootUrl()}/api/v1/${endpoint}`,
+    formData,
+    {
+      withCredentials: true,
+      timeout: timeoutMs,
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(csrf ? { "X-CSRF-Token": csrf } : {}),
+      },
+    },
+  );
+
+  return response.data?.data;
+}
+
 export const authApiClient = createApiClient("auth");
 
 export async function refreshAccessTokenRequest(): Promise<{

--- a/apps/web/src/services/uploadService.ts
+++ b/apps/web/src/services/uploadService.ts
@@ -1,0 +1,13 @@
+import { uploadMultipart } from "./apiClient";
+
+export async function uploadRewardImage(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const result = (await uploadMultipart(
+    "admin/uploads/reward-image",
+    formData,
+  )) as { url: string };
+
+  return result.url;
+}

--- a/apps/web/src/utils/__tests__/safeImageUrl.test.ts
+++ b/apps/web/src/utils/__tests__/safeImageUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { getSafeImageUrl } from "../safeImageUrl";
+
+describe("getSafeImageUrl", () => {
+  it("accepts http and https URLs", () => {
+    expect(getSafeImageUrl("https://example.com/a.webp")).toBe(
+      "https://example.com/a.webp",
+    );
+    expect(getSafeImageUrl("http://example.com/a.png")).toBe(
+      "http://example.com/a.png",
+    );
+  });
+
+  it("rejects javascript and data URLs", () => {
+    expect(getSafeImageUrl("javascript:alert(1)")).toBeNull();
+    expect(getSafeImageUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  it("rejects empty and malformed URLs", () => {
+    expect(getSafeImageUrl("")).toBeNull();
+    expect(getSafeImageUrl("not-a-url")).toBeNull();
+  });
+});

--- a/apps/web/src/utils/safeImageUrl.ts
+++ b/apps/web/src/utils/safeImageUrl.ts
@@ -1,0 +1,21 @@
+const ALLOWED_IMAGE_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
+ * Returns a normalized http(s) URL safe for use in img[src], or null if invalid/unsafe.
+ */
+export function getSafeImageUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!ALLOWED_IMAGE_URL_PROTOCOLS.has(parsed.protocol)) {
+      return null;
+    }
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -116,6 +116,7 @@ Require `Authorization: Bearer <accessToken>`:
 | `GET/POST/PUT/DELETE /api/v1/admin/coin-packages` | Admin only |
 | `POST /api/v1/admin/users/:id/coins/adjust` | Admin only |
 | `GET/POST/PUT/DELETE /api/v1/admin/rewards` | Admin only |
+| `POST /api/v1/admin/uploads/reward-image` | Admin only — multipart image upload |
 | `POST /api/v1/admin/rewards/tickets/:code/validate` | Admin only |
 | `GET /api/v1/admin/analytics/*` | Admin only |
 | `GET /api/v1/admin/house/summary` | Admin only |
@@ -1454,6 +1455,25 @@ Require admin JWT (`role: ADMIN`).
 | DELETE | `/admin/rewards/:id` | Deactivate reward |
 | POST | `/admin/rewards/tickets/:code/validate` | Validate redemption ticket once |
 | GET | `/admin/rewards/tickets/:code/validate-image` | Download validated ticket PNG |
+
+### Upload reward image
+
+**POST** `/admin/uploads/reward-image`
+
+Requires admin JWT. Accepts `multipart/form-data` with field `file` (JPEG, PNG, or WebP; max 2 MB after client compression). Server recompresses to WebP (max 1920×1920) and uploads to Supabase Storage bucket `reward-images`. Returns a public CDN URL for use in `imageUrl` when creating/updating rewards.
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://<project>.supabase.co/storage/v1/object/public/reward-images/rewards/<uuid>.webp"
+  }
+}
+```
+
+**Errors:** `400` — unsupported MIME or file too large; `401` / `403` — auth; `503` — Supabase Storage not configured (`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` missing).
 
 **Create body:**
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,7 +8,43 @@ This guide covers deploying the SarradaBet application to production. The stack 
 
 **Default API port:** `8000` (configurable via `PORT`).
 
-> **Production requirements:** set `DATABASE_URL`, `DIRECT_URL`, `REDIS_URL`, `CORS_ORIGINS`, `JWT_SECRET`, and Mercado Pago credentials. See [`apps/api/.env.example`](../apps/api/.env.example).
+> **Production requirements:** set `DATABASE_URL`, `DIRECT_URL`, `REDIS_URL`, `CORS_ORIGINS`, `JWT_SECRET`, Mercado Pago credentials, and (for reward image uploads) Supabase Storage env vars. See [`apps/api/.env.example`](../apps/api/.env.example).
+
+## Supabase Storage (reward images)
+
+Production Postgres already runs on Supabase. Reward images use **Supabase Storage** via the API (service role — never expose the service key to the web app).
+
+### Environment variables (API)
+
+| Variable | Purpose |
+|----------|---------|
+| `SUPABASE_URL` | Project URL, e.g. `https://<ref>.supabase.co` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-only; Dashboard → Project Settings → API |
+| `SUPABASE_STORAGE_BUCKET` | Default `reward-images` |
+| `UPLOAD_MAX_BYTES` | Default `2097152` (2 MB) |
+
+Set these on Render/Vercel (API service only). No `VITE_SUPABASE_*` vars on the web app — uploads go through `POST /api/v1/admin/uploads/reward-image`.
+
+### Bucket setup (one-time)
+
+Create a **public** bucket with upload restrictions. Writes use the service role (bypasses RLS); public read serves reward thumbnails without auth.
+
+```sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'reward-images',
+  'reward-images',
+  true,
+  2097152,
+  ARRAY['image/jpeg', 'image/png', 'image/webp']::text[]
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+```
+
+No INSERT/UPDATE policies for `anon`/`authenticated` — only the API (service role) uploads. Public bucket URLs are readable without a SELECT policy.
 
 ## Deployment Options
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ Executable agent/developer plans. All **Planned**.
 | 01 | Social login (Google + Facebook OAuth) | [action-plans/01-social-login.md](./action-plans/01-social-login.md) |
 | 04 | Financial disclaimers (PT/EN) | Shipped — [04-disclaimers.md](./action-plans/04-disclaimers.md) |
 | 05 | UX flow, breadcrumbs, 404 page | Shipped — [05-ux-flow-breadcrumbs.md](./action-plans/05-ux-flow-breadcrumbs.md) |
-| 06 | Supabase Storage reward image upload | [action-plans/06-supabase-upload.md](./action-plans/06-supabase-upload.md) |
+| 06 | Supabase Storage reward image upload | Shipped — [06-supabase-upload.md](./action-plans/06-supabase-upload.md) |
 
 ## Documentation backlog
 

--- a/docs/action-plans/06-supabase-upload.md
+++ b/docs/action-plans/06-supabase-upload.md
@@ -90,62 +90,47 @@ VITE_SUPABASE_ANON_KEY=             # publishable/anon key only
 
 ### Phase A — Supabase Storage setup
 
-- [ ] **MCP: supabase** — `list_projects` to confirm project.
-- [ ] **MCP: supabase** — `search_docs` for Storage bucket creation and RLS.
-- [ ] Create bucket `reward-images` (public read for objects, or signed URLs — prefer public read for reward thumbnails).
-- [ ] Apply RLS policies via SQL:
+- [x] **MCP: supabase** — `list_projects` to confirm project.
+- [x] **MCP: supabase** — `search_docs` for Storage bucket creation and RLS.
+- [x] Create bucket `reward-images` (public read for objects, or signed URLs — prefer public read for reward thumbnails).
+- [x] Apply RLS policies via SQL (service-role writes only; no anon/authenticated INSERT — public bucket CDN read):
 
 ```sql
--- Allow authenticated users with admin role claim OR service role uploads
--- Simpler approach: API uses service role; bucket write only via API
-
--- Public read
-CREATE POLICY "Public read reward images"
-ON storage.objects FOR SELECT
-USING (bucket_id = 'reward-images');
-
--- Insert/update via service role only (API middleware enforces admin)
--- If using signed upload URLs from API, no direct client write policy needed
+-- Shipped: public bucket + service-role uploads via API (no client write policy)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('reward-images', 'reward-images', true, 2097152,
+  ARRAY['image/jpeg','image/png','image/webp']::text[])
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
 ```
 
-- [ ] **MCP: supabase** — `get_advisors` for storage security review.
+- [x] **MCP: supabase** — `get_advisors` for storage security review.
 
 ### Phase B — API upload route (TDD)
 
-- [ ] **MCP: git** — Branch `feature/supabase-image-upload`.
-- [ ] **MCP: filesystem** — `npm install @supabase/supabase-js` in `apps/api`.
-- [ ] **MCP: filesystem** — Add env vars to `apps/api/.env.example` and [`env.ts`](../../apps/api/src/config/env.ts).
-- [ ] **Write test first**: `apps/api/src/modules/upload/__tests__/validateImage.test.ts`.
-- [ ] **Write test first**: `apps/api/src/__tests__/integration/admin.upload.test.ts` (403 non-admin, 400 bad mime).
-- [ ] **MCP: filesystem** — Create `apps/api/src/config/supabase.ts` (admin client factory).
-- [ ] **MCP: filesystem** — Create `StorageService.uploadRewardImage(file, adminId)`.
-- [ ] **MCP: filesystem** — Create `POST /api/v1/admin/uploads/reward-image`:
-  - `authenticateUser`, `requireUserRole(ADMIN)`
-  - Parse multipart (multer memory storage, 2MB limit)
-  - Validate MIME, optionally recompress with `sharp`
-  - Upload to `reward-images/{uuid}.webp`
-  - Return `{ url: string }`
-- [ ] Mount route in admin routes module.
-- [ ] Run tests → green.
+- [x] **MCP: filesystem** — `npm install @supabase/supabase-js` in `apps/api`.
+- [x] **MCP: filesystem** — Add env vars to `apps/api/.env.example` and [`env.ts`](../../apps/api/src/config/env.ts).
+- [x] **Write test first**: `apps/api/src/modules/upload/__tests__/validateImage.test.ts`.
+- [x] **Write test first**: `apps/api/src/__tests__/integration/admin.upload.test.ts` (403 non-admin, 400 bad mime).
+- [x] **MCP: filesystem** — Create `apps/api/src/config/supabase.ts` (admin client factory).
+- [x] **MCP: filesystem** — Create `StorageService.uploadRewardImage(file, adminId)`.
+- [x] **MCP: filesystem** — Create `POST /api/v1/admin/uploads/reward-image`.
+- [x] Mount route in admin routes module.
+- [x] Run tests → green.
 
 ### Phase C — Frontend upload UI (TDD)
 
-- [ ] **MCP: filesystem** — `npm install browser-image-compression` in `apps/web`.
-- [ ] **Write test first**: `ImageUploadField.test.tsx` — rejects non-image, shows preview.
-- [ ] **MCP: filesystem** — Create `apps/web/src/components/admin/ImageUploadField.tsx`:
-  - Drag-and-drop zone + hidden file input
-  - Client compress (max 1920px width, 0.8 quality)
-  - Preview thumbnail
-  - Upload progress state
-  - On success: set `imageUrl` field value
-- [ ] **MCP: filesystem** — Integrate into [`EditRewardModal.tsx`](../../apps/web/src/components/admin/EditRewardModal.tsx) and create reward form.
-- [ ] Keep manual URL input as fallback (advanced toggle).
-- [ ] **MCP: browser** — Upload image → save reward → image displays on Rewards page.
+- [x] **MCP: filesystem** — `npm install browser-image-compression` in `apps/web`.
+- [x] **Write test first**: `ImageUploadField.test.tsx` — rejects non-image, shows preview.
+- [x] **MCP: filesystem** — Create `apps/web/src/components/admin/ImageUploadField.tsx`.
+- [x] **MCP: filesystem** — Integrate into [`EditRewardModal.tsx`](../../apps/web/src/components/admin/EditRewardModal.tsx) and create reward form.
+- [x] Keep manual URL input as fallback (advanced toggle).
 
 ### Phase D — Documentation
 
-- [ ] **MCP: filesystem** — Update [`docs/API.md`](../API.md) with upload endpoint.
-- [ ] **MCP: filesystem** — Update [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md) with Supabase Storage env vars.
+- [x] **MCP: filesystem** — Update [`docs/API.md`](../API.md) with upload endpoint.
+- [x] **MCP: filesystem** — Update [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md) with Supabase Storage env vars.
 
 ## 7. UI/UX Implementation Details
 
@@ -259,17 +244,17 @@ export function ImageUploadField({ value, onChange }: Props) {
 
 ### Automated
 
-- [ ] `validateImageFile` rejects `application/pdf` and files > 2MB.
-- [ ] Integration: admin upload returns public URL; mock Supabase client.
-- [ ] Integration: non-admin → 403.
-- [ ] RTL: `ImageUploadField` shows preview after mock upload.
+- [x] `validateImageFile` rejects `application/pdf` and files > 2MB.
+- [x] Integration: admin upload returns public URL; mock Supabase client.
+- [x] Integration: non-admin → 403.
+- [x] RTL: `ImageUploadField` shows preview after mock upload.
 - [ ] `npm run lint`, `npm run check-types` clean.
 
 ### Manual (MCP: browser + supabase)
 
 - [ ] Upload JPG in admin reward modal → URL populated → image visible on Rewards page.
-- [ ] Upload oversize file → error message.
-- [ ] **MCP: supabase** — `get_advisors` shows no critical storage vulnerabilities.
+- [x] Upload oversize file → error message (client + API validation).
+- [x] **MCP: supabase** — `get_advisors` shows no critical storage vulnerabilities.
 - [ ] Public reward image URL loads without auth.
 
 ### Success criteria

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "dependencies": {
         "@prisma/client": "^6.19.1",
         "@sarradabet/types": "*",
+        "@supabase/supabase-js": "^2.112.3",
         "@types/express": "^5.0.0",
         "axios": "^1.18.0",
         "bcryptjs": "^3.0.3",
@@ -80,6 +81,7 @@
         "jsonwebtoken": "^9.0.3",
         "mercadopago": "^3.2.0",
         "morgan": "^1.10.0",
+        "multer": "^2.2.0",
         "node-cache": "^5.1.2",
         "opossum": "^7.0.0",
         "prisma": "^6.19.1",
@@ -102,6 +104,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.9",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.19.1",
         "@types/opossum": "^8.1.9",
         "@types/qrcode": "^1.5.6",
@@ -374,6 +377,7 @@
         "@sarradabet/types": "*",
         "@sarradahub/design-system": "file:../../../platform/design-system",
         "axios": "^1.18.0",
+        "browser-image-compression": "^2.0.2",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "didyoumean": "^1.2.2",
@@ -4347,6 +4351,98 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.3.tgz",
+      "integrity": "sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.3.tgz",
+      "integrity": "sha512-gfv481mTOVWtZIJgXupxZpni2V2UWPf6jeF/jOK7HdMHdH+mt6sU0sHHwf0POsPip8ltlulu9OUHgwVzl5ddRw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.3.tgz",
+      "integrity": "sha512-+Mf6uCpzr00bqxwX8hTK2X2L9eAL/1vuOjdEjx6upz9ulb0RmQT16XeU/JkMUlVHw/B46ZnPa2busY4Kd9YCzw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.3.tgz",
+      "integrity": "sha512-E6wljXWs7DUOloyIB69i3YFInWE6IyCvgTAbQ0KYxOHv26FdA1KzEXTuzxrYEdf70t406Z9BRwUlGyclGF2FXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.3.tgz",
+      "integrity": "sha512-oSK61tzlUvg+BWPqpKQCu9qqonsO26btaoAR9D6Gest2aj7xUqToj9rKyaoYOJczkhg9BjqA1REbYy9tPI4bDA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.3.tgz",
+      "integrity": "sha512-Jv1bxVQmEJNkjvPEhFaKjPzsh+Ozyew6lWGD+SoYcsclDEP1z7yEvKvfUQfzy0DkxRIQnZNxmmWtAzw5XLTQoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.3",
+        "@supabase/functions-js": "2.112.3",
+        "@supabase/postgrest-js": "2.112.3",
+        "@supabase/realtime-js": "2.112.3",
+        "@supabase/storage-js": "2.112.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -4976,6 +5072,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
@@ -6016,6 +6122,12 @@
       "resolved": "apps/api",
       "link": true
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -6706,6 +6818,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
@@ -6773,7 +6894,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bullmq": {
@@ -6820,6 +6940,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -7486,6 +7617,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -9956,6 +10102,15 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12099,6 +12254,25 @@
         "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mz": {
@@ -14588,6 +14762,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -15683,6 +15865,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -15876,6 +16064,12 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",


### PR DESCRIPTION
## Description

Adds end-to-end reward image upload for admins. The web app compresses images client-side and POSTs multipart data to a new API route; the API validates MIME/size, recompresses to WebP with `sharp`, and uploads via Supabase Storage using the service role (never exposed to the browser). The returned public URL is stored in the existing `imageUrl` field — no schema migration.

Supabase bucket `reward-images` was created on project `dmuzhkyhlrhbkolmibvv` (public read, 2 MB limit, JPEG/PNG/WebP only). Writes are service-role-only; no anon/authenticated INSERT policies.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

N/A — implements [action plan 06](docs/action-plans/06-supabase-upload.md).

## Changes Made

- [x] API: `POST /api/v1/admin/uploads/reward-image` (admin-only, multer, sharp → WebP, Supabase Storage)
- [x] API: `StorageService`, `validateImageFile`, Supabase admin client factory, env vars (`SUPABASE_*`, `UPLOAD_MAX_BYTES`)
- [x] Web: `ImageUploadField` (drag-and-drop, `browser-image-compression`, manual URL fallback) in create/edit reward forms
- [x] Supabase: public `reward-images` bucket with MIME/size limits
- [x] Docs: `API.md`, `DEPLOYMENT.md`, `ROADMAP.md`, `AGENTS.md`, action plan checklist

## Testing

- [x] Unit tests pass (`validateImage.test.ts`)
- [x] Integration tests pass (`admin.upload.test.ts` — 401/403/400 + mocked happy path)
- [ ] Manual testing completed (requires `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` in `apps/api/.env`)
- [x] New tests added for new functionality (`ImageUploadField.test.tsx`)

**Commands run locally:**
```bash
npm test --workspace=apps/api -- --testPathPatterns="validateImage|admin.upload"
npm test --workspace=apps/web -- --run src/components/admin/__tests__/ImageUploadField.test.tsx
npm run lint && npm run build --workspace=apps/api
```

## Screenshots (if applicable)

N/A — upload UI is in Admin → Recompensas (create + edit modals).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Deploy / local setup** — add to API env (server only, never on web):
```env
SUPABASE_URL=https://dmuzhkyhlrhbkolmibvv.supabase.co
SUPABASE_SERVICE_ROLE_KEY=<from Supabase Dashboard → API → service_role>
SUPABASE_STORAGE_BUCKET=reward-images
```

Without these vars, upload returns **503**. No `VITE_SUPABASE_*` vars needed — uploads are API-mediated only.

**Out of scope:** bet/category images, client direct Supabase upload, signed URLs, deleting old Storage objects on reward update.