### PR TITLE
fix(api): send CSRF cookies cross-site on Vercel

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,6 +20,10 @@ import { logger } from "./utils/logger";
 
 export const app = express();
 
+if (config.NODE_ENV === "production" || process.env.VERCEL) {
+  app.set("trust proxy", 1);
+}
+
 app.use(compression({ threshold: 1024 }));
 
 app.use(securityHeaders);

--- a/apps/api/src/config/__tests__/cookies.test.ts
+++ b/apps/api/src/config/__tests__/cookies.test.ts
@@ -1,0 +1,45 @@
+import {
+  getAuthCookieOptions,
+  getCookieSameSite,
+  getCookieSecure,
+  getCsrfCookieName,
+} from "../cookies";
+
+describe("cookie helpers", () => {
+  it("uses lax insecure cookies outside production", () => {
+    expect(getCookieSecure()).toBe(false);
+    expect(getCookieSameSite()).toBe("lax");
+    expect(getCsrfCookieName()).toBe("x-csrf-token");
+    expect(getAuthCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: "lax",
+      path: "/",
+    });
+  });
+
+  it("uses Secure SameSite=None cookies when production config is loaded", async () => {
+    jest.resetModules();
+    jest.doMock("../env", () => ({
+      config: {
+        COOKIE_SECURE: undefined,
+        NODE_ENV: "production",
+      },
+    }));
+
+    const cookies = await import("../cookies");
+
+    expect(cookies.getCookieSecure()).toBe(true);
+    expect(cookies.getCookieSameSite()).toBe("none");
+    expect(cookies.getCsrfCookieName()).toBe("__Host-sarradabet.x-csrf-token");
+    expect(cookies.getAuthCookieOptions()).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: "none",
+      path: "/",
+    });
+
+    jest.dontMock("../env");
+    jest.resetModules();
+  });
+});

--- a/apps/api/src/config/cookies.ts
+++ b/apps/api/src/config/cookies.ts
@@ -1,0 +1,31 @@
+import { config } from "./env";
+
+export function getCookieSecure(): boolean {
+  return config.COOKIE_SECURE ?? config.NODE_ENV === "production";
+}
+
+export function getCookieSameSite(): "lax" | "none" {
+  // Web and API are separate sites on vercel.app (public suffix), so Lax
+  // cookies are omitted from credentialed cross-origin POSTs.
+  return getCookieSecure() ? "none" : "lax";
+}
+
+export function getCsrfCookieName(): string {
+  return getCookieSecure()
+    ? "__Host-sarradabet.x-csrf-token"
+    : "x-csrf-token";
+}
+
+export function getAuthCookieOptions(): {
+  httpOnly: true;
+  secure: boolean;
+  sameSite: "lax" | "none";
+  path: "/";
+} {
+  return {
+    httpOnly: true,
+    secure: getCookieSecure(),
+    sameSite: getCookieSameSite(),
+    path: "/",
+  };
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -89,7 +89,9 @@ const envSchema = z.object({
   COOKIE_SECURE: z
     .enum(["true", "false"])
     .optional()
-    .transform((value) => value === "true"),
+    .transform((value): boolean | undefined =>
+      value === undefined ? undefined : value === "true",
+    ),
   MERCADOPAGO_ACCESS_TOKEN: z.string().optional(),
   MERCADOPAGO_WEBHOOK_SECRET: z.string().optional(),
   MERCADOPAGO_NOTIFICATION_URL: z.string().url().optional(),

--- a/apps/api/src/core/middleware/CsrfMiddleware.ts
+++ b/apps/api/src/core/middleware/CsrfMiddleware.ts
@@ -1,5 +1,9 @@
 import { Request, Response, NextFunction } from "express";
 import { doubleCsrf } from "csrf-csrf";
+import {
+  getAuthCookieOptions,
+  getCsrfCookieName,
+} from "../../config/cookies";
 import { config } from "../../config/env";
 import { ForbiddenError } from "../errors/AppError";
 
@@ -9,16 +13,6 @@ function getCsrfSecret(): string {
     throw new Error("JWT_SECRET or API_KEY is required for CSRF protection");
   }
   return secret;
-}
-
-function getCookieSecure(): boolean {
-  return config.COOKIE_SECURE ?? config.NODE_ENV === "production";
-}
-
-function getCsrfCookieName(): string {
-  return getCookieSecure()
-    ? "__Host-sarradabet.x-csrf-token"
-    : "x-csrf-token";
 }
 
 function getSessionIdentifier(req: Request): string {
@@ -50,12 +44,7 @@ const {
   getSecret: () => getCsrfSecret(),
   getSessionIdentifier,
   cookieName: getCsrfCookieName(),
-  cookieOptions: {
-    sameSite: "lax",
-    path: "/",
-    secure: getCookieSecure(),
-    httpOnly: true,
-  },
+  cookieOptions: getAuthCookieOptions(),
   getCsrfTokenFromRequest: (req) => {
     const headerToken = req.headers["x-csrf-token"];
     return typeof headerToken === "string" ? headerToken : undefined;

--- a/apps/api/src/modules/auth/controllers/AuthController.ts
+++ b/apps/api/src/modules/auth/controllers/AuthController.ts
@@ -3,6 +3,7 @@ import { AuthService } from "../services/AuthService";
 import { UserService } from "../../user/services/UserService";
 import { ApiResponse } from "../../../utils/api/response";
 import { UnauthorizedError, AppError } from "../../../core/errors/AppError";
+import { getAuthCookieOptions } from "../../../config/cookies";
 import { config } from "../../../config/env";
 import {
   getRefreshTokenMaxAgeMs,
@@ -49,28 +50,14 @@ export class AuthController {
   }
 
   private setRefreshCookie(res: Response, refreshToken: string): void {
-    const cookieSecure =
-      config.COOKIE_SECURE ?? config.NODE_ENV === "production";
-
     res.cookie(config.REFRESH_TOKEN_COOKIE_NAME, refreshToken, {
-      httpOnly: true,
-      secure: cookieSecure,
-      sameSite: "lax",
-      path: "/",
+      ...getAuthCookieOptions(),
       maxAge: getRefreshTokenMaxAgeMs(),
     });
   }
 
   private clearRefreshCookie(res: Response): void {
-    const cookieSecure =
-      config.COOKIE_SECURE ?? config.NODE_ENV === "production";
-
-    res.clearCookie(config.REFRESH_TOKEN_COOKIE_NAME, {
-      httpOnly: true,
-      secure: cookieSecure,
-      sameSite: "lax",
-      path: "/",
-    });
+    res.clearCookie(config.REFRESH_TOKEN_COOKIE_NAME, getAuthCookieOptions());
   }
 
   register = async (req: Request, res: Response): Promise<void> => {


### PR DESCRIPTION
## Description

Login from `sarradabet-web.vercel.app` was getting **403 Invalid CSRF token** because CSRF and refresh cookies used `SameSite=Lax` (and were not `Secure`). `vercel.app` is on the public suffix list, so the web and API hosts are different sites and the browser never sent those cookies on credentialed POSTs.

Unset `COOKIE_SECURE` was also parsed as `false`, so the production default never applied. This PR sets production cookies to `Secure; SameSite=None` and enables Express `trust proxy` behind Vercel so rate-limit sees the real client IP.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

N/A (production Vercel login 403 after CSRF secret was restored)

## Changes Made

- [x] Treat unset `COOKIE_SECURE` as undefined so production still defaults to Secure cookies
- [x] Share CSRF and refresh cookie options: `Secure; SameSite=None` in production
- [x] Set `trust proxy` on Vercel/production so `express-rate-limit` uses `X-Forwarded-For`

## Testing

- [x] Unit tests pass (`CsrfMiddleware` + new cookie helper tests)
- [ ] Integration tests pass (local Postgres was not running)
- [ ] Manual testing completed (needs this deploy; login from the web app)
- [x] New tests added for new functionality

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

`JWT_SECRET` is already set on the Vercel API project; this PR is the remaining code fix for cross-site cookies. After merge, confirm login from `https://sarradabet-web.vercel.app` (GET `/api/v1/auth/csrf-token` then POST `/api/v1/auth/login` with `X-CSRF-Token` and credentials). Local `SameSite=Lax` behavior is unchanged.

Direct POSTs to `/api/v1/auth/login` without a CSRF cookie + header will still return 403 — that is expected.


Made with [Cursor](https://cursor.com)