### PR TITLE
fix(web): group bets by embedded category when list is empty

### DIFF
--- a/apps/web/src/hooks/useCategories.ts
+++ b/apps/web/src/hooks/useCategories.ts
@@ -31,8 +31,8 @@ export function useCategories(params?: {
     () => categoryService.getCategoriesWithPagination(params),
     {
       staleTime: 5 * 60 * 1000, // 5 minutes - longer cache for categories
-      refetchOnMount: false, // Don't refetch on mount if data exists
-      refetchOnWindowFocus: false, // Don't refetch on window focus
+      refetchOnMount: true,
+      refetchOnWindowFocus: false,
     },
   );
 }

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -89,11 +89,24 @@ const HomePage: React.FC = () => {
     }
 
     bets.forEach((bet: Bet) => {
-      if (bet.categoryId && groups.has(bet.categoryId)) {
-        groups.get(bet.categoryId)!.bets.push(bet);
-      } else {
+      const categoryId = bet.categoryId;
+      if (!categoryId) {
         groups.get("uncategorized")!.bets.push(bet);
+        return;
       }
+
+      if (!groups.has(categoryId)) {
+        const fromList = categories.find((c) => c.id === categoryId);
+        groups.set(categoryId, {
+          category:
+            bet.category ??
+            fromList ??
+            ({ id: categoryId, title: `Categoria ${categoryId}` } as Category),
+          bets: [],
+        });
+      }
+
+      groups.get(categoryId)!.bets.push(bet);
     });
 
     return Array.from(groups.entries())


### PR DESCRIPTION
Fallback to bet.category for sportsbook grouping and refetch categories on mount so stale empty cache no longer shows Sem Categoria.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Fixes #(issue number)

## Changes Made

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] New tests added for new functionality

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Any additional information that reviewers should know.
