### PR TITLE
feat(web): phone masks and Portuguese API error handling

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -41,7 +41,7 @@ app.use(
         : config.NODE_ENV === "development"
           ? 1000
           : 100,
-    message: "Too many requests from this IP, please try again later",
+    message: "Muitas requisições deste IP. Tente mais tarde.",
     skipSuccessfulRequests:
       config.NODE_ENV === "development" || config.NODE_ENV === "test",
   }),

--- a/apps/api/src/core/middleware/ErrorHandler.ts
+++ b/apps/api/src/core/middleware/ErrorHandler.ts
@@ -16,7 +16,7 @@ export const errorHandler = (
   _next: NextFunction,
 ): void => {
   let statusCode = 500;
-  let message = "Ocorreu um erro genérico. Tente novamente.";
+  let message: string;
   let errors:
     | Array<{ field?: string; message: string; code?: string; stack?: string }>
     | undefined;

--- a/apps/api/src/core/middleware/ErrorHandler.ts
+++ b/apps/api/src/core/middleware/ErrorHandler.ts
@@ -16,7 +16,7 @@ export const errorHandler = (
   _next: NextFunction,
 ): void => {
   let statusCode = 500;
-  let message = "Internal server error";
+  let message = "Ocorreu um erro genérico. Tente novamente.";
   let errors:
     | Array<{ field?: string; message: string; code?: string; stack?: string }>
     | undefined;
@@ -43,16 +43,22 @@ export const errorHandler = (
 
   if (error === invalidCsrfTokenError) {
     statusCode = 403;
-    message = "Invalid CSRF token";
+    message = "Token de segurança inválido. Recarregue a página.";
   } else if (error instanceof AppError) {
     statusCode = error.statusCode;
     message = error.message;
-    errors = error.context
-      ? [{ message: String((error.context as any).message ?? message) }]
-      : undefined;
+    const contextErrors = error.context?.errors;
+    if (Array.isArray(contextErrors) && contextErrors.length > 0) {
+      errors = contextErrors as Array<{
+        field?: string;
+        message: string;
+        code?: string;
+        stack?: string;
+      }>;
+    }
   } else if (error instanceof ZodError) {
     statusCode = 400;
-    message = "Validation failed";
+    message = "Falha na validação";
     errors = error.errors.map((err) => ({
       field: err.path.join("."),
       message: err.message,
@@ -65,14 +71,14 @@ export const errorHandler = (
     errors = prismaError.errors;
   } else if (error instanceof PrismaClientValidationError) {
     statusCode = 400;
-    message = "Invalid data provided";
+    message = "Dados inválidos fornecidos";
     errors = [{ message: error.message }];
   } else if (error.name === "ValidationError") {
     statusCode = 400;
     message = error.message;
   } else if (process.env.NODE_ENV === "production") {
     statusCode = 500;
-    message = "Something went wrong";
+    message = "Ocorreu um erro genérico. Tente novamente.";
     errors = undefined;
   } else {
     statusCode = 500;
@@ -126,31 +132,31 @@ const handlePrismaError = (error: PrismaClientKnownRequestError) => {
     case "P2002":
       return {
         statusCode: 409,
-        message: "A record with this data already exists",
+        message: "Já existe um registro com estes dados.",
         errors: [{ field: "unique_constraint", message: error.message }],
       };
     case "P2025":
       return {
         statusCode: 404,
-        message: "Record not found",
+        message: "Registro não encontrado",
         errors: [{ message: error.message }],
       };
     case "P2003":
       return {
         statusCode: 400,
-        message: "Invalid reference to related record",
+        message: "Referência inválida a outro registro",
         errors: [{ message: error.message }],
       };
     case "P2014":
       return {
         statusCode: 400,
-        message: "Invalid data for relation",
+        message: "Dados inválidos para a relação",
         errors: [{ message: error.message }],
       };
     default:
       return {
         statusCode: 500,
-        message: "Database operation failed",
+        message: "Falha na operação do banco de dados",
         errors: [{ message: error.message }],
       };
   }

--- a/apps/api/src/core/middleware/ValidationMiddleware.ts
+++ b/apps/api/src/core/middleware/ValidationMiddleware.ts
@@ -25,7 +25,7 @@ export const validateRequest = (
           `Validation failed for ${property}. Errors: ${errors.length}. Fields: ${fields}`,
         );
 
-        throw new ValidationError("Validation failed", { errors });
+        throw new ValidationError("Falha na validação", { errors });
       }
 
       logger.debug(`Validation passed for ${property}`);
@@ -55,5 +55,5 @@ export const validateZodError = (error: ZodError): ValidationError => {
     code: err.code,
   }));
 
-  return new ValidationError("Validation failed", { errors });
+  return new ValidationError("Falha na validação", { errors });
 };

--- a/apps/api/src/core/validation/ValidationSchemas.ts
+++ b/apps/api/src/core/validation/ValidationSchemas.ts
@@ -6,10 +6,10 @@ import {
 
 export const BrazilianPhoneSchema = z
   .string()
-  .min(8, "Phone is required")
-  .max(20, "Phone cannot exceed 20 characters")
+  .min(8, "Telefone é obrigatório")
+  .max(20, "Telefone não pode exceder 20 caracteres")
   .trim()
-  .refine(isValidBrazilianPhone, "Invalid Brazilian phone number")
+  .refine(isValidBrazilianPhone, "Telefone brasileiro inválido")
   .transform(normalizeBrazilianPhone);
 
 export const IdSchema = z
@@ -61,53 +61,53 @@ export const UpdateBetOddsSchema = z.object({
 export const RegisterUserSchema = z.object({
   username: z
     .string()
-    .min(3, "Username must be at least 3 characters")
-    .max(50, "Username cannot exceed 50 characters")
+    .min(3, "Usuário deve ter pelo menos 3 caracteres")
+    .max(50, "Usuário não pode exceder 50 caracteres")
     .regex(
       /^[a-zA-Z0-9_]+$/,
-      "Username can only contain letters, numbers, and underscores",
+      "Usuário só pode conter letras, números e sublinhados",
     )
     .trim(),
   email: z
     .string()
-    .email("Invalid email format")
-    .max(255, "Email cannot exceed 255 characters")
+    .email("Formato de e-mail inválido")
+    .max(255, "E-mail não pode exceder 255 caracteres")
     .toLowerCase()
     .trim(),
   password: z
     .string()
-    .min(6, "Password must be at least 6 characters")
-    .max(100, "Password cannot exceed 100 characters"),
+    .min(6, "Senha deve ter pelo menos 6 caracteres")
+    .max(100, "Senha não pode exceder 100 caracteres"),
   phone: BrazilianPhoneSchema,
 });
 
 export const UserLoginSchema = z.object({
-  username: z.string().min(1, "Username or email is required").trim(),
-  password: z.string().min(1, "Password is required"),
+  username: z.string().min(1, "Usuário ou e-mail é obrigatório").trim(),
+  password: z.string().min(1, "Senha é obrigatória"),
 });
 
 export const UpdateUserSchema = z.object({
   username: z
     .string()
-    .min(3, "Username must be at least 3 characters")
-    .max(50, "Username cannot exceed 50 characters")
+    .min(3, "Usuário deve ter pelo menos 3 caracteres")
+    .max(50, "Usuário não pode exceder 50 caracteres")
     .regex(
       /^[a-zA-Z0-9_]+$/,
-      "Username can only contain letters, numbers, and underscores",
+      "Usuário só pode conter letras, números e sublinhados",
     )
     .trim()
     .optional(),
   email: z
     .string()
-    .email("Invalid email format")
-    .max(255, "Email cannot exceed 255 characters")
+    .email("Formato de e-mail inválido")
+    .max(255, "E-mail não pode exceder 255 caracteres")
     .toLowerCase()
     .trim()
     .optional(),
   password: z
     .string()
-    .min(6, "Password must be at least 6 characters")
-    .max(100, "Password cannot exceed 100 characters")
+    .min(6, "Senha deve ter pelo menos 6 caracteres")
+    .max(100, "Senha não pode exceder 100 caracteres")
     .optional(),
   role: z.enum(["USER", "ADMIN"]).optional(),
   phone: BrazilianPhoneSchema.optional(),

--- a/apps/api/src/modules/auth/controllers/AuthController.ts
+++ b/apps/api/src/modules/auth/controllers/AuthController.ts
@@ -36,7 +36,7 @@ export class AuthController {
     err: unknown,
     fallbackStatusCode: number = 400,
   ): void {
-    let message = "An error occurred";
+    let message = "Ocorreu um erro genérico. Tente novamente.";
     let statusCode = fallbackStatusCode;
 
     if (err instanceof AppError) {

--- a/apps/api/src/modules/auth/routes/auth.routes.ts
+++ b/apps/api/src/modules/auth/routes/auth.routes.ts
@@ -18,14 +18,14 @@ const isTestEnv = config.NODE_ENV === "test";
 const loginRateLimit = createRateLimit({
   windowMs: 15 * 60 * 1000,
   max: isTestEnv ? 10_000 : config.AUTH_LOGIN_RATE_LIMIT_MAX,
-  message: "Too many login attempts, please try again later",
+  message: "Muitas tentativas de login. Tente mais tarde.",
   skipSuccessfulRequests: false,
 });
 
 const registerRateLimit = createRateLimit({
   windowMs: 15 * 60 * 1000,
   max: isTestEnv ? 10_000 : config.AUTH_REGISTER_RATE_LIMIT_MAX,
-  message: "Too many registration attempts, please try again later",
+  message: "Muitas tentativas de cadastro. Tente mais tarde.",
   skipSuccessfulRequests: false,
 });
 

--- a/apps/api/src/modules/auth/services/AuthService.ts
+++ b/apps/api/src/modules/auth/services/AuthService.ts
@@ -71,7 +71,7 @@ export class AuthService {
     });
 
     if (!user) {
-      throw new UnauthorizedError("Invalid credentials");
+      throw new UnauthorizedError("Usuário ou senha inválidos.");
     }
 
     const isPasswordValid = await comparePassword(
@@ -79,7 +79,7 @@ export class AuthService {
       user.passwordHash,
     );
     if (!isPasswordValid) {
-      throw new UnauthorizedError("Invalid credentials");
+      throw new UnauthorizedError("Usuário ou senha inválidos.");
     }
 
     return this.issueTokens(user);
@@ -94,16 +94,16 @@ export class AuthService {
     });
 
     if (!existingToken) {
-      throw new UnauthorizedError("Invalid refresh token");
+      throw new UnauthorizedError("Sessão expirada. Faça login novamente.");
     }
 
     if (existingToken.revokedAt) {
       await this.revokeAllUserRefreshTokens(existingToken.userId);
-      throw new UnauthorizedError("Refresh token reuse detected");
+      throw new UnauthorizedError("Sessão inválida. Faça login novamente.");
     }
 
     if (existingToken.expiresAt <= new Date()) {
-      throw new UnauthorizedError("Refresh token expired");
+      throw new UnauthorizedError("Sessão expirada. Faça login novamente.");
     }
 
     const { user } = existingToken;
@@ -213,13 +213,13 @@ export class AuthService {
 
     if (existingUser) {
       if (existingUser.username === username) {
-        throw new ValidationError("Username already exists");
+        throw new ValidationError("Este usuário já está cadastrado.");
       }
       if (existingUser.email === email) {
-        throw new ValidationError("Email already exists");
+        throw new ValidationError("Este e-mail já está cadastrado.");
       }
       if (existingUser.phone === phone) {
-        throw new ValidationError("Phone already exists");
+        throw new ValidationError("Este telefone já está cadastrado.");
       }
     }
   }

--- a/apps/api/src/modules/user/services/UserService.ts
+++ b/apps/api/src/modules/user/services/UserService.ts
@@ -70,13 +70,13 @@ export class UserService {
 
       if (existingUser) {
         if (data.username && existingUser.username === data.username) {
-          throw new ValidationError("Username already exists");
+          throw new ValidationError("Este usuário já está cadastrado.");
         }
         if (data.email && existingUser.email === data.email) {
-          throw new ValidationError("Email already exists");
+          throw new ValidationError("Este e-mail já está cadastrado.");
         }
         if (data.phone && existingUser.phone === data.phone) {
-          throw new ValidationError("Phone already exists");
+          throw new ValidationError("Este telefone já está cadastrado.");
         }
       }
     }
@@ -116,7 +116,7 @@ export class UserService {
     await this.findById(id);
 
     if (id === requesterId) {
-      throw new ForbiddenError("Cannot delete your own account");
+      throw new ForbiddenError("Você não pode excluir sua própria conta.");
     }
 
     await prisma.user.delete({

--- a/apps/web/src/components/admin/EditUserModal.tsx
+++ b/apps/web/src/components/admin/EditUserModal.tsx
@@ -6,6 +6,13 @@ import { Button } from "../ui/Button";
 import { ErrorMessage } from "../ui/ErrorMessage";
 import { userService } from "../../services/UserService";
 import { getApiErrorMessage } from "../../utils/apiError";
+import { formatPhoneFromApi, formatPhoneMask } from "../../utils/phoneMask";
+
+function FieldHint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs text-sportsbook-muted -mt-2">{children}</p>
+  );
+}
 
 interface EditUserModalProps {
   isOpen: boolean;
@@ -40,7 +47,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
       setFormData({
         username: user.username,
         email: user.email,
-        phone: user.phone,
+        phone: formatPhoneFromApi(user.phone),
         role: user.role,
         password: "",
       });
@@ -141,6 +148,9 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
           id="edit-user-email"
           type="email"
           label="E-mail"
+          placeholder="seu@email.com"
+          autoComplete="email"
+          inputMode="email"
           value={formData.email ?? ""}
           onChange={(event) =>
             setFormData((current) => ({
@@ -151,20 +161,25 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
           className={sportsbookFieldClass}
           required
         />
+        <FieldHint>Use um e-mail válido (ex.: nome@gmail.com)</FieldHint>
         <Input
           id="edit-user-phone"
           type="tel"
           label="Telefone"
+          inputMode="numeric"
+          autoComplete="tel"
+          placeholder="(11) 99999-9999"
           value={formData.phone ?? ""}
           onChange={(event) =>
             setFormData((current) => ({
               ...current,
-              phone: event.target.value,
+              phone: formatPhoneMask(event.target.value),
             }))
           }
           className={sportsbookFieldClass}
           required
         />
+        <FieldHint>DDD + número (celular com 9)</FieldHint>
         <Select
           id="edit-user-role"
           label="Função"

--- a/apps/web/src/core/hooks/useApi.ts
+++ b/apps/web/src/core/hooks/useApi.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { ApiResponse, ApiError } from "../interfaces/IService";
+import {
+  GENERIC_API_ERROR_MESSAGE,
+  getApiErrorMessage,
+} from "../../utils/apiError";
 
 export interface UseApiState<T> {
   data: T | null;
@@ -54,7 +58,10 @@ export function useApi<T>(
           onSuccess?.(response.data);
           return response.data;
         } else {
-          const errorMessage = response.message || "Request failed";
+          const errorMessage = getApiErrorMessage(
+            { message: response.message },
+            "Falha na requisição",
+          );
 
           setState((prev) => ({
             ...prev,
@@ -65,13 +72,19 @@ export function useApi<T>(
           return null;
         }
       } catch (error: unknown) {
+        const message = getApiErrorMessage(
+          error,
+          GENERIC_API_ERROR_MESSAGE,
+        );
         const e = error as ApiError & {
-          message?: string;
           errors?: ApiError["errors"];
+          url?: string;
+          method?: string;
+          requestId?: string;
         };
         const apiError: ApiError = {
           success: false,
-          message: e?.message || "An unexpected error occurred",
+          message,
           errors: e?.errors,
           url: e?.url,
           method: e?.method,

--- a/apps/web/src/core/hooks/useMutation.ts
+++ b/apps/web/src/core/hooks/useMutation.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback } from "react";
 import { ApiResponse, ApiError } from "../interfaces/IService";
+import {
+  GENERIC_API_ERROR_MESSAGE,
+  getApiErrorMessage,
+} from "../../utils/apiError";
 
 export interface UseMutationOptions<TData, TVariables, TContext = unknown> {
   onMutate?: (variables: TVariables) => TContext | void | Promise<TContext | void>;
@@ -61,7 +65,10 @@ export function useMutation<TData, TVariables, TContext = unknown>(
           return response.data;
         }
 
-        const errorMessage = response.message || "Mutation failed";
+        const errorMessage = getApiErrorMessage(
+          { message: response.message },
+          "Falha na operação",
+        );
         const mutationError: ApiError = {
           success: false,
           message: errorMessage,
@@ -77,10 +84,11 @@ export function useMutation<TData, TVariables, TContext = unknown>(
         onSettled?.(null, mutationError, variables);
         return null;
       } catch (err: unknown) {
-        const e = err as { message?: string; errors?: ApiError["errors"] };
+        const message = getApiErrorMessage(err, GENERIC_API_ERROR_MESSAGE);
+        const e = err as { errors?: ApiError["errors"] };
         const mutationError: ApiError = {
           success: false,
-          message: e?.message || "An unexpected error occurred",
+          message,
           errors: e?.errors,
         };
 

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -5,6 +5,7 @@ import type {
   PeakHourEntry,
   PixRevenuePoint,
 } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import {
   analyticsService,
   type AnalyticsFilters,
@@ -34,9 +35,7 @@ export function useAnalytics(filters: AnalyticsFilters) {
       setPixRevenue(revenueData);
       setPeakHours(hoursData);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar análises",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar análises"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useCoinBalance.ts
+++ b/apps/web/src/hooks/useCoinBalance.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { getApiErrorMessage } from "../utils/apiError";
 import { coinService } from "../services/CoinPaymentService";
 import { useAuth } from "./useAuth";
 
@@ -21,7 +22,7 @@ export function useCoinBalance() {
       const result = await coinService.getBalance();
       setBalance(result.balance);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load balance");
+      setError(getApiErrorMessage(err, "Erro ao carregar saldo"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useCoinTransactions.ts
+++ b/apps/web/src/hooks/useCoinTransactions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { CoinTransaction } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import { coinService } from "../services/CoinPaymentService";
 import { useAuth } from "./useAuth";
 
@@ -25,9 +26,7 @@ export function useCoinTransactions(limit = 10) {
       setTransactions(result.data.items);
       setTotal(result.data.total);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load transactions",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar transações"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useLeaderboard.ts
+++ b/apps/web/src/hooks/useLeaderboard.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { LeaderboardEntry } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import { statsService } from "../services/statsService";
 
 export function useLeaderboard(limit = 100) {
@@ -15,7 +16,7 @@ export function useLeaderboard(limit = 100) {
       setEntries(result);
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : "Erro ao carregar ranking",
+        getApiErrorMessage(err, "Erro ao carregar ranking"),
       );
     } finally {
       setLoading(false);

--- a/apps/web/src/hooks/useMyPendingRedemptions.ts
+++ b/apps/web/src/hooks/useMyPendingRedemptions.ts
@@ -1,5 +1,6 @@
 import type { UserRewardRedemption } from "@sarradabet/types";
 import { useCallback, useEffect, useState } from "react";
+import { getApiErrorMessage } from "../utils/apiError";
 import { rewardService } from "../services/rewardService";
 import { useAuth } from "./useAuth";
 
@@ -22,9 +23,7 @@ export function useMyPendingRedemptions() {
       const result = await rewardService.getMyPendingRedemptions();
       setRedemptions(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar resgates",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar resgates"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useMyValidatedRedemptions.ts
+++ b/apps/web/src/hooks/useMyValidatedRedemptions.ts
@@ -1,5 +1,6 @@
 import type { UserRewardRedemption } from "@sarradabet/types";
 import { useCallback, useEffect, useState } from "react";
+import { getApiErrorMessage } from "../utils/apiError";
 import { rewardService } from "../services/rewardService";
 import { useAuth } from "./useAuth";
 
@@ -22,9 +23,7 @@ export function useMyValidatedRedemptions() {
       const result = await rewardService.getMyValidatedRedemptions();
       setRedemptions(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar histórico",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar histórico"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useRewards.ts
+++ b/apps/web/src/hooks/useRewards.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { Reward } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import { rewardService } from "../services/rewardService";
 
 export function useRewards() {
@@ -14,9 +15,7 @@ export function useRewards() {
       const result = await rewardService.listActive();
       setRewards(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar recompensas",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar recompensas"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useUserDashboard.ts
+++ b/apps/web/src/hooks/useUserDashboard.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { UserDashboardResponse } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import { dashboardService } from "../services/dashboardService";
 import { useAuth } from "./useAuth";
 
@@ -24,9 +25,7 @@ export function useUserDashboard(page = 1, limit = 10) {
       const result = await dashboardService.getDashboard({ page, limit });
       setDashboard(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar dashboard",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar dashboard"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/hooks/useUserStats.ts
+++ b/apps/web/src/hooks/useUserStats.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { UserStats } from "@sarradabet/types";
+import { getApiErrorMessage } from "../utils/apiError";
 import { statsService } from "../services/statsService";
 import { useAuth } from "./useAuth";
 
@@ -22,9 +23,7 @@ export function useUserStats() {
       const result = await statsService.getMyStats();
       setStats(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar estatísticas",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar estatísticas"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/pages/AdminCoinPackagesPage.tsx
+++ b/apps/web/src/pages/AdminCoinPackagesPage.tsx
@@ -6,6 +6,7 @@ import EditCoinPackageModal from "../components/admin/EditCoinPackageModal";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
 import { sportsbookFieldClass } from "../components/ui/SportsbookModal";
+import { getApiErrorMessage } from "../utils/apiError";
 import { adminCoinPackageService } from "../services/CoinPaymentService";
 
 function formatCurrency(cents: number): string {
@@ -38,7 +39,7 @@ const AdminCoinPackagesPage: React.FC = () => {
       const result = await adminCoinPackageService.listAll();
       setPackages(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao carregar pacotes");
+      setError(getApiErrorMessage(err, "Erro ao carregar pacotes"));
     } finally {
       setLoading(false);
     }
@@ -64,7 +65,7 @@ const AdminCoinPackagesPage: React.FC = () => {
       setForm(emptyForm);
       await loadPackages();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao criar pacote");
+      setError(getApiErrorMessage(err, "Erro ao criar pacote"));
     } finally {
       setSaving(false);
     }
@@ -81,7 +82,7 @@ const AdminCoinPackagesPage: React.FC = () => {
       }
       await loadPackages();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao atualizar pacote");
+      setError(getApiErrorMessage(err, "Erro ao atualizar pacote"));
     }
   };
 

--- a/apps/web/src/pages/AdminDashboard.tsx
+++ b/apps/web/src/pages/AdminDashboard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { Plus } from "@sarradahub/design-system";
 import { formatDistanceToNow } from "date-fns";
 import { ptBR } from "date-fns/locale";
+import { getApiErrorMessage } from "../utils/apiError";
 import { Button } from "../components/ui/Button";
 import CreateBetModal from "../components/CreateBetModal";
 import CreateCategoryModal from "../components/CreateCategoryModal";
@@ -78,7 +79,7 @@ const AdminDashboard: React.FC = () => {
       .then(setHouseSummary)
       .catch((err: unknown) => {
         setHouseError(
-          err instanceof Error ? err.message : "Erro ao carregar receita da casa",
+          getApiErrorMessage(err, "Erro ao carregar receita da casa"),
         );
       });
   }, []);
@@ -179,9 +180,7 @@ const AdminDashboard: React.FC = () => {
       link.click();
       URL.revokeObjectURL(url);
     } catch (err) {
-      setHouseError(
-        err instanceof Error ? err.message : "Erro ao exportar CSV",
-      );
+      setHouseError(getApiErrorMessage(err, "Erro ao exportar CSV"));
     } finally {
       setExporting(false);
     }

--- a/apps/web/src/pages/AdminLogin.tsx
+++ b/apps/web/src/pages/AdminLogin.tsx
@@ -7,6 +7,7 @@ import PasswordInput from "../components/ui/PasswordInput";
 import { Input } from "@sarradahub/design-system";
 import { sportsbookFieldClass } from "../components/ui/SportsbookModal";
 import { useAuth } from "../hooks/useAuth";
+import { getApiErrorMessage } from "../utils/apiError";
 
 interface LoginForm {
   username: string;
@@ -49,9 +50,7 @@ const AdminLogin: React.FC = () => {
 
       navigate("/admin/dashboard");
     } catch (loginError) {
-      setError(
-        loginError instanceof Error ? loginError.message : "Erro desconhecido",
-      );
+      setError(getApiErrorMessage(loginError, "Erro ao entrar"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/pages/AdminUsersPage.tsx
+++ b/apps/web/src/pages/AdminUsersPage.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from "../components/ui/LoadingSpinner";
 import { Modal } from "../components/ui/Modal";
 import { useAuth } from "../hooks/useAuth";
 import { userService } from "../services/UserService";
+import { getApiErrorMessage } from "../utils/apiError";
 
 function formatDate(value: string): string {
   return new Date(value).toLocaleString("pt-BR");
@@ -31,7 +32,7 @@ const AdminUsersPage: React.FC = () => {
       const result = await userService.listUsers();
       setUsers(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao carregar usuários");
+      setError(getApiErrorMessage(err, "Erro ao carregar usuários"));
     } finally {
       setLoading(false);
     }
@@ -53,7 +54,7 @@ const AdminUsersPage: React.FC = () => {
       setConfirmUser(null);
       await loadUsers();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao excluir usuário");
+      setError(getApiErrorMessage(err, "Erro ao excluir usuário"));
     } finally {
       setDeletingId(null);
     }

--- a/apps/web/src/pages/CoinsPage.tsx
+++ b/apps/web/src/pages/CoinsPage.tsx
@@ -13,6 +13,7 @@ import { sportsbookFieldClass } from "../components/ui/SportsbookModal";
 import { useSocketEvent } from "../core/hooks/useSocket";
 import { useCoinBalance } from "../hooks/useCoinBalance";
 import { useCoinTransactions } from "../hooks/useCoinTransactions";
+import { getApiErrorMessage } from "../utils/apiError";
 import { usePixPurchase } from "../hooks/usePixPurchase";
 import { coinService } from "../services/CoinPaymentService";
 import { DISCLAIMERS } from "../constants/disclaimers";
@@ -106,7 +107,7 @@ const CoinsPage: React.FC = () => {
         setPackages(result);
       } catch (err) {
         setPackagesError(
-          err instanceof Error ? err.message : "Erro ao carregar pacotes",
+          getApiErrorMessage(err, "Erro ao carregar pacotes"),
         );
       } finally {
         setPackagesLoading(false);

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import PasswordInput from "../components/ui/PasswordInput";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { sportsbookFieldClass } from "../components/ui/SportsbookModal";
 import { useAuth } from "../hooks/useAuth";
+import { getApiErrorMessage } from "../utils/apiError";
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -33,7 +34,7 @@ const LoginPage: React.FC = () => {
       const redirect = searchParams.get("redirect") || "/";
       navigate(redirect, { replace: true });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao entrar");
+      setError(getApiErrorMessage(err, "Erro ao entrar"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "../hooks/useAuth";
 import { useMyPendingRedemptions } from "../hooks/useMyPendingRedemptions";
 import { useMyValidatedRedemptions } from "../hooks/useMyValidatedRedemptions";
 import { useUserStats } from "../hooks/useUserStats";
+import { getApiErrorMessage } from "../utils/apiError";
 import { userService } from "../services/UserService";
 import type { UserPublic } from "@sarradabet/types";
 
@@ -53,9 +54,7 @@ const ProfilePage: React.FC = () => {
       const result = await userService.getById(user.id);
       setProfile(result);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Erro ao carregar perfil",
-      );
+      setError(getApiErrorMessage(err, "Erro ao carregar perfil"));
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -7,6 +7,14 @@ import PasswordInput from "../components/ui/PasswordInput";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import { sportsbookFieldClass } from "../components/ui/SportsbookModal";
 import { useAuth } from "../hooks/useAuth";
+import { getApiErrorMessage } from "../utils/apiError";
+import { formatPhoneMask } from "../utils/phoneMask";
+
+function FieldHint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs text-sportsbook-muted -mt-2">{children}</p>
+  );
+}
 
 const RegisterPage: React.FC = () => {
   const navigate = useNavigate();
@@ -31,7 +39,7 @@ const RegisterPage: React.FC = () => {
       const redirect = searchParams.get("redirect") || "/coins";
       navigate(redirect, { replace: true });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao cadastrar");
+      setError(getApiErrorMessage(err, "Erro ao cadastrar"));
     } finally {
       setLoading(false);
     }
@@ -72,6 +80,9 @@ const RegisterPage: React.FC = () => {
           <Input
             label="E-mail"
             type="email"
+            placeholder="seu@email.com"
+            autoComplete="email"
+            inputMode="email"
             value={formData.email}
             onChange={(event) =>
               setFormData((current) => ({
@@ -82,19 +93,24 @@ const RegisterPage: React.FC = () => {
             required
             className={sportsbookFieldClass}
           />
+          <FieldHint>Use um e-mail válido (ex.: nome@gmail.com)</FieldHint>
           <Input
             label="Telefone"
+            type="tel"
+            inputMode="numeric"
+            autoComplete="tel"
             placeholder="(11) 99999-9999"
             value={formData.phone}
             onChange={(event) =>
               setFormData((current) => ({
                 ...current,
-                phone: event.target.value,
+                phone: formatPhoneMask(event.target.value),
               }))
             }
             required
             className={sportsbookFieldClass}
           />
+          <FieldHint>DDD + número (celular com 9)</FieldHint>
           <PasswordInput
             id="register-password"
             name="password"

--- a/apps/web/src/services/apiClient.ts
+++ b/apps/web/src/services/apiClient.ts
@@ -3,6 +3,10 @@ import axios, {
   AxiosInstance,
   InternalAxiosRequestConfig,
 } from "axios";
+import {
+  GENERIC_API_ERROR_MESSAGE,
+  normalizeAxiosErrorMessage,
+} from "../utils/apiError";
 
 type AuthHandlers = {
   getAccessToken: () => string | null;
@@ -93,6 +97,10 @@ function isAuthEndpoint(url: string | undefined): boolean {
     url.includes("/auth/logout");
 }
 
+function rejectNormalized(error: AxiosError): Promise<never> {
+  return Promise.reject(normalizeAxiosErrorMessage(error, GENERIC_API_ERROR_MESSAGE));
+}
+
 function attachAuthInterceptors(client: AxiosInstance): void {
   client.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
     const token = authHandlers.getAccessToken();
@@ -143,7 +151,7 @@ function attachAuthInterceptors(client: AxiosInstance): void {
         originalRequest._retry ||
         isAuthEndpoint(originalRequest.url)
       ) {
-        return Promise.reject(error);
+        return rejectNormalized(error);
       }
 
       originalRequest._retry = true;
@@ -160,7 +168,7 @@ function attachAuthInterceptors(client: AxiosInstance): void {
 
       if (!newToken) {
         authHandlers.onUnauthorized();
-        return Promise.reject(error);
+        return rejectNormalized(error);
       }
 
       originalRequest.headers.Authorization = `Bearer ${newToken}`;

--- a/apps/web/src/utils/__tests__/apiError.test.ts
+++ b/apps/web/src/utils/__tests__/apiError.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { AxiosError } from "axios";
+import {
+  GENERIC_API_ERROR_MESSAGE,
+  getApiErrorMessage,
+  normalizeAxiosErrorMessage,
+} from "../apiError";
+
+function axiosError(
+  status: number,
+  data?: Record<string, unknown>,
+  message = "Request failed with status code 400",
+): AxiosError {
+  const error = new AxiosError(message);
+  error.response = {
+    status,
+    data,
+    statusText: "",
+    headers: {},
+    config: {} as AxiosError["response"] extends infer R
+      ? R extends { config: infer C }
+        ? C
+        : never
+      : never,
+  };
+  return error;
+}
+
+describe("getApiErrorMessage", () => {
+  it("returns field error when top message is generic validation", () => {
+    const err = axiosError(400, {
+      message: "Validation failed",
+      errors: [{ field: "email", message: "Formato de e-mail inválido." }],
+    });
+    expect(getApiErrorMessage(err)).toBe("Formato de e-mail inválido.");
+  });
+
+  it("translates known English auth messages", () => {
+    const err = axiosError(400, { message: "Email already exists" });
+    expect(getApiErrorMessage(err)).toBe("Este e-mail já está cadastrado.");
+  });
+
+  it("returns generic PT for 500", () => {
+    const err = axiosError(500, { message: "Internal server error" });
+    expect(getApiErrorMessage(err)).toBe(GENERIC_API_ERROR_MESSAGE);
+  });
+
+  it("returns connection message for network errors", () => {
+    const err = new AxiosError("Network Error");
+    expect(getApiErrorMessage(err)).toBe(
+      "Erro de conexão. Verifique sua internet e tente novamente.",
+    );
+  });
+
+  it("uses contextual fallback for generic axios message without body", () => {
+    const err = axiosError(400, undefined);
+    expect(getApiErrorMessage(err, "Erro ao cadastrar")).toBe("Erro ao cadastrar");
+  });
+
+  it("normalizeAxiosErrorMessage overwrites error.message", () => {
+    const err = axiosError(400, { message: "Phone already exists" });
+    normalizeAxiosErrorMessage(err);
+    expect(err.message).toBe("Este telefone já está cadastrado.");
+  });
+});

--- a/apps/web/src/utils/__tests__/phoneMask.test.ts
+++ b/apps/web/src/utils/__tests__/phoneMask.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatPhoneFromApi,
+  formatPhoneMask,
+  stripPhoneDigits,
+} from "../phoneMask";
+
+describe("phoneMask", () => {
+  it("formats mobile number while typing", () => {
+    expect(formatPhoneMask("1")).toBe("(1");
+    expect(formatPhoneMask("11")).toBe("(11");
+    expect(formatPhoneMask("119")).toBe("(11) 9");
+    expect(formatPhoneMask("11999991234")).toBe("(11) 99999-1234");
+  });
+
+  it("formats landline (10 digits)", () => {
+    expect(formatPhoneMask("1133334444")).toBe("(11) 3333-4444");
+  });
+
+  it("strips country code when pasting 55 prefix", () => {
+    expect(formatPhoneMask("5511999991234")).toBe("(11) 99999-1234");
+    expect(stripPhoneDigits("5511999991234")).toBe("11999991234");
+  });
+
+  it("limits to 11 national digits", () => {
+    expect(formatPhoneMask("119999912345678")).toBe("(11) 99999-1234");
+  });
+
+  it("formats phone from API storage", () => {
+    expect(formatPhoneFromApi("5511999991234")).toBe("(11) 99999-1234");
+    expect(formatPhoneFromApi("11999991234")).toBe("(11) 99999-1234");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(formatPhoneMask("")).toBe("");
+    expect(stripPhoneDigits("")).toBe("");
+  });
+});

--- a/apps/web/src/utils/apiError.ts
+++ b/apps/web/src/utils/apiError.ts
@@ -1,4 +1,4 @@
-import { isAxiosError } from "axios";
+import { AxiosError, isAxiosError } from "axios";
 
 export const GENERIC_API_ERROR_MESSAGE =
   "Ocorreu um erro genérico. Tente novamente.";

--- a/apps/web/src/utils/apiError.ts
+++ b/apps/web/src/utils/apiError.ts
@@ -1,25 +1,166 @@
 import { isAxiosError } from "axios";
 
+export const GENERIC_API_ERROR_MESSAGE =
+  "Ocorreu um erro genérico. Tente novamente.";
+
+const GENERIC_API_MESSAGES = new Set([
+  "validation failed",
+  "falha na validação",
+  "internal server error",
+  "something went wrong",
+  "an error occurred",
+  "request failed",
+  "an unexpected error occurred",
+  "invalid data provided",
+]);
+
+const EN_TO_PT: Record<string, string> = {
+  "Username already exists": "Este usuário já está cadastrado.",
+  "Email already exists": "Este e-mail já está cadastrado.",
+  "Phone already exists": "Este telefone já está cadastrado.",
+  "Invalid credentials": "Usuário ou senha inválidos.",
+  "Invalid refresh token": "Sessão expirada. Faça login novamente.",
+  "Refresh token reuse detected": "Sessão inválida. Faça login novamente.",
+  "Refresh token expired": "Sessão expirada. Faça login novamente.",
+  "Too many login attempts, please try again later":
+    "Muitas tentativas de login. Tente mais tarde.",
+  "Too many registration attempts, please try again later":
+    "Muitas tentativas de cadastro. Tente mais tarde.",
+  "Too many requests from this IP, please try again later":
+    "Muitas requisições. Tente mais tarde.",
+  "Invalid CSRF token": "Token de segurança inválido. Recarregue a página.",
+  "Validation failed": "Falha na validação.",
+  "Invalid email format": "Formato de e-mail inválido.",
+  "Invalid Brazilian phone number": "Telefone brasileiro inválido.",
+  "A record with this data already exists":
+    "Já existe um registro com estes dados.",
+  "Record not found": "Registro não encontrado.",
+  "Invalid reference to related record": "Referência inválida a outro registro.",
+  "Invalid data for relation": "Dados inválidos para a relação.",
+  "Database operation failed": "Falha na operação do banco de dados.",
+  "Internal server error": GENERIC_API_ERROR_MESSAGE,
+  "Something went wrong": GENERIC_API_ERROR_MESSAGE,
+  "An error occurred": GENERIC_API_ERROR_MESSAGE,
+  "Unauthorized access": "Acesso não autorizado.",
+  "Forbidden access": "Acesso negado.",
+  "Insufficient permissions": "Permissões insuficientes.",
+  "Invalid or expired token": "Token inválido ou expirado.",
+  "Usuário ou senha inválidos.": "Usuário ou senha inválidos.",
+  "Este usuário já está cadastrado.": "Este usuário já está cadastrado.",
+  "Este e-mail já está cadastrado.": "Este e-mail já está cadastrado.",
+  "Este telefone já está cadastrado.": "Este telefone já está cadastrado.",
+  "Falha na validação": "Falha na validação",
+  "Muitas tentativas de login. Tente mais tarde.":
+    "Muitas tentativas de login. Tente mais tarde.",
+  "Muitas tentativas de cadastro. Tente mais tarde.":
+    "Muitas tentativas de cadastro. Tente mais tarde.",
+  "Muitas requisições. Tente mais tarde.":
+    "Muitas requisições. Tente mais tarde.",
+  "Ocorreu um erro genérico. Tente novamente.": GENERIC_API_ERROR_MESSAGE,
+  "No file uploaded": "Nenhum arquivo enviado.",
+  "Unsupported image type": "Tipo de imagem não suportado.",
+  "File too large": "Arquivo muito grande.",
+};
+
+function isGenericMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  if (GENERIC_API_MESSAGES.has(normalized)) {
+    return true;
+  }
+  if (/^request failed with status code \d+$/i.test(message.trim())) {
+    return true;
+  }
+  return false;
+}
+
+function translateKnownMessage(message: string): string {
+  const trimmed = message.trim();
+  if (EN_TO_PT[trimmed]) {
+    return EN_TO_PT[trimmed];
+  }
+  return trimmed;
+}
+
+type ApiErrorPayload = {
+  message?: string;
+  details?: string;
+  errors?: Array<{ field?: string; message?: string }>;
+};
+
+function extractFromPayload(
+  data: ApiErrorPayload | undefined,
+  status?: number,
+): string | null {
+  if (!data) {
+    return null;
+  }
+
+  const fieldMessage = data.errors?.find((e) => e.message?.trim())?.message;
+  const topMessage = data.message?.trim();
+  const details = data.details?.trim();
+
+  if (fieldMessage && (!topMessage || isGenericMessage(topMessage))) {
+    return translateKnownMessage(fieldMessage);
+  }
+
+  if (topMessage && !isGenericMessage(topMessage)) {
+    return translateKnownMessage(topMessage);
+  }
+
+  if (fieldMessage) {
+    return translateKnownMessage(fieldMessage);
+  }
+
+  if (details && !isGenericMessage(details)) {
+    return translateKnownMessage(details);
+  }
+
+  if (topMessage) {
+    return translateKnownMessage(topMessage);
+  }
+
+  if (status && status >= 500) {
+    return GENERIC_API_ERROR_MESSAGE;
+  }
+
+  return null;
+}
+
 export function getApiErrorMessage(
   error: unknown,
   fallback = "Erro ao processar solicitação",
 ): string {
   if (isAxiosError(error)) {
-    const data = error.response?.data as
-      | { message?: string; details?: string; errors?: Array<{ message?: string }> }
-      | undefined;
+    const status = error.response?.status;
+    const data = error.response?.data as ApiErrorPayload | undefined;
+    const fromPayload = extractFromPayload(data, status);
 
-    if (data?.message) {
-      return data.message;
+    if (fromPayload) {
+      return fromPayload;
     }
 
-    if (data?.details) {
-      return data.details;
+    if (!error.response) {
+      if (error.code === "ECONNABORTED") {
+        return "Tempo esgotado. Tente novamente.";
+      }
+      if (error.message === "Network Error") {
+        return "Erro de conexão. Verifique sua internet e tente novamente.";
+      }
+      return GENERIC_API_ERROR_MESSAGE;
     }
 
-    if (data?.errors?.[0]?.message) {
-      return data.errors[0].message;
+    if (status && status >= 500) {
+      return GENERIC_API_ERROR_MESSAGE;
     }
+
+    if (error.message && !isGenericMessage(error.message)) {
+      return translateKnownMessage(error.message);
+    }
+
+    return fallback;
   }
 
   if (
@@ -28,12 +169,26 @@ export function getApiErrorMessage(
     "message" in error &&
     typeof (error as { message?: unknown }).message === "string"
   ) {
-    return (error as { message: string }).message;
+    const msg = (error as { message: string }).message;
+    if (msg && !isGenericMessage(msg)) {
+      return translateKnownMessage(msg);
+    }
   }
 
-  if (error instanceof Error && error.message) {
-    return error.message;
+  if (error instanceof Error && error.message && !isGenericMessage(error.message)) {
+    return translateKnownMessage(error.message);
   }
 
   return fallback;
+}
+
+/** Normalize Axios error so err.message is user-facing PT text. */
+export function normalizeAxiosErrorMessage(
+  error: AxiosError,
+  fallback = GENERIC_API_ERROR_MESSAGE,
+): AxiosError {
+  const userMessage = getApiErrorMessage(error, fallback);
+  error.message = userMessage;
+  (error as AxiosError & { userMessage?: string }).userMessage = userMessage;
+  return error;
 }

--- a/apps/web/src/utils/phoneMask.ts
+++ b/apps/web/src/utils/phoneMask.ts
@@ -1,0 +1,40 @@
+/** Strip non-digits; drop leading 55 when present (max 11 national digits). */
+export function stripPhoneDigits(value: string): string {
+  let digits = value.replace(/\D/g, "");
+
+  if (digits.startsWith("55") && digits.length > 11) {
+    digits = digits.slice(2);
+  }
+
+  return digits.slice(0, 11);
+}
+
+/** Format as (DD) 99999-9999 or (DD) 9999-9999 while typing. */
+export function formatPhoneMask(value: string): string {
+  const digits = stripPhoneDigits(value);
+
+  if (digits.length === 0) {
+    return "";
+  }
+
+  if (digits.length <= 2) {
+    return `(${digits}`;
+  }
+
+  if (digits.length <= 6) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  }
+
+  if (digits.length <= 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7, 11)}`;
+}
+
+/** Format API-stored phone (5511999991234) for display in inputs. */
+export function formatPhoneFromApi(phone: string): string {
+  const digits = phone.replace(/\D/g, "");
+  const national = digits.startsWith("55") ? digits.slice(2) : digits;
+  return formatPhoneMask(national);
+}


### PR DESCRIPTION
## Description

Melhora a UX de cadastro com máscara brasileira de telefone e hints nos campos de e-mail/telefone (Register + admin). Centraliza mensagens de erro da API em português no web via `getApiErrorMessage` e interceptor Axios, e alinha respostas de auth/validação da API para PT (incluindo fallbacks genéricos explícitos).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

Fixes #(issue number)

## Changes Made

- [x] `phoneMask.ts` + máscara/hints em `RegisterPage` e `EditUserModal`
- [x] `getApiErrorMessage` reforçado (campo Zod, 5xx genérico, mapa EN→PT) + interceptor Axios
- [x] `useApi` / `useMutation` e catches da app migrados para mensagens PT
- [x] API: auth, Zod de cadastro/usuário, ErrorHandler, Prisma e rate limits em português
- [x] Fix: import ausente de `useCoinTransactions` em `CoinsPage` (tela branca pós-cadastro)

## Testing

- [x] Unit tests pass (`phoneMask.test.ts`, `apiError.test.ts`, `CoinsPage.test.tsx`)
- [ ] Integration tests pass
- [x] Manual testing completed (cadastro → redirect `/coins`)
- [x] New tests added for new functionality

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Erros genéricos (5xx, rede, Axios) exibem: **"Ocorreu um erro genérico. Tente novamente."**
- Mensagens ainda em inglês no backend são cobertas temporariamente pelo mapa EN→PT no web até migração completa.

Made with [Cursor](https://cursor.com)